### PR TITLE
Updated drop sources for Syndicate items

### DIFF
--- a/queued_updates/items/Agkuza Blade.json
+++ b/queued_updates/items/Agkuza Blade.json
@@ -1,0 +1,56 @@
+{
+    "_id": "5783bf59d9b6753790c89e98",
+    "tags": [
+        "parts",
+        "archwing",
+        "blade"
+    ],
+    "icon": "icons/en/Agkuza_Set.037f45c1777df3ce5657b0c40aac04b1.png",
+    "thumb": "icons/en/thumbs/Agkuza_Set.037f45c1777df3ce5657b0c40aac04b1.128x128.png",
+    "icon_format": "land",
+    "sub_icon": "sub_icons/blade_128x128.png",
+    "url_name": "agkuza_blade",
+    "tradable": true,
+    "part_of_set": [
+        "582b0f890af25410b099f7fe",
+        "5783bf59d9b6753790c89e98",
+        "5783bf5ed9b6753790c89e99",
+        "5783bf62d9b6753790c89e9a"
+    ],
+    "set_root": false,
+    "en": {
+        "item_name": "Agkuza Blade",
+        "description": "<p>This weapon deals primarily  Puncture damage.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Agkuza",
+        "drop": [
+            {
+                "name": "New Loka",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Агкуза Клинок",
+        "description": "<p>Разрывайте врагов на части с этим массивным клинком с крюком</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%90%D0%B3%D0%BA%D1%83%D0%B7%D0%B0",
+        "drop": [
+            {
+                "name": "New Loka",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "악쿠자 블레이드",
+        "description": "<p>This weapon deals primarily  Puncture damage.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Agkuza",
+        "drop": [
+            {
+                "name": "New Loka",
+                "link": null
+            }
+        ]
+    },
+    "mastery_level": 0,
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Agkuza Guard.json
+++ b/queued_updates/items/Agkuza Guard.json
@@ -1,0 +1,55 @@
+{
+    "_id": "5783bf5ed9b6753790c89e99",
+    "tags": [
+        "blueprint",
+        "archwing"
+    ],
+    "icon": "icons/en/Agkuza_Set.037f45c1777df3ce5657b0c40aac04b1.png",
+    "thumb": "icons/en/thumbs/Agkuza_Set.037f45c1777df3ce5657b0c40aac04b1.128x128.png",
+    "icon_format": "land",
+    "sub_icon": "sub_icons/generic_guard_128x128.png",
+    "url_name": "agkuza_guard",
+    "tradable": true,
+    "part_of_set": [
+        "582b0f890af25410b099f7fe",
+        "5783bf59d9b6753790c89e98",
+        "5783bf5ed9b6753790c89e99",
+        "5783bf62d9b6753790c89e9a"
+    ],
+    "set_root": false,
+    "en": {
+        "item_name": "Agkuza Guard",
+        "description": "<p>This weapon deals primarily  Puncture damage.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Agkuza",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Агкуза",
+        "description": "<p>Разрывайте врагов на части с этим массивным клинком с крюком</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%90%D0%B3%D0%BA%D1%83%D0%B7%D0%B0",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "악쿠자 가드",
+        "description": "<p>This weapon deals primarily  Puncture damage.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Agkuza",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            }
+        ]
+    },
+    "mastery_level": 0,
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Agkuza Handle.json
+++ b/queued_updates/items/Agkuza Handle.json
@@ -1,0 +1,56 @@
+{
+    "_id": "5783bf62d9b6753790c89e9a",
+    "tags": [
+        "parts",
+        "archwing",
+        "handle"
+    ],
+    "icon": "icons/en/Agkuza_Set.037f45c1777df3ce5657b0c40aac04b1.png",
+    "thumb": "icons/en/thumbs/Agkuza_Set.037f45c1777df3ce5657b0c40aac04b1.128x128.png",
+    "icon_format": "land",
+    "sub_icon": "sub_icons/handle_128x128.png",
+    "url_name": "agkuza_handle",
+    "tradable": true,
+    "part_of_set": [
+        "582b0f890af25410b099f7fe",
+        "5783bf59d9b6753790c89e98",
+        "5783bf5ed9b6753790c89e99",
+        "5783bf62d9b6753790c89e9a"
+    ],
+    "set_root": false,
+    "en": {
+        "item_name": "Agkuza Handle",
+        "description": "<p>This weapon deals primarily  Puncture damage.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Agkuza",
+        "drop": [
+            {
+                "name": "Red Veil",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Агкуза Рукоять",
+        "description": "<p>Разрывайте врагов на части с этим массивным клинком с крюком</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%90%D0%B3%D0%BA%D1%83%D0%B7%D0%B0",
+        "drop": [
+            {
+                "name": "Red Veil",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "악쿠자 핸들",
+        "description": "<p>This weapon deals primarily  Puncture damage.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Agkuza",
+        "drop": [
+            {
+                "name": "Red Veil",
+                "link": null
+            }
+        ]
+    },
+    "mastery_level": 0,
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Agkuza Set.json
+++ b/queued_updates/items/Agkuza Set.json
@@ -1,0 +1,40 @@
+{
+    "_id": "582b0f890af25410b099f7fe",
+    "tags": [
+        "parts",
+        "archwing",
+        "set"
+    ],
+    "icon": "icons/en/Agkuza_Set.037f45c1777df3ce5657b0c40aac04b1.png",
+    "thumb": "icons/en/thumbs/Agkuza_Set.037f45c1777df3ce5657b0c40aac04b1.128x128.png",
+    "icon_format": "land",
+    "url_name": "agkuza_set",
+    "tradable": true,
+    "part_of_set": [
+        "582b0f890af25410b099f7fe",
+        "5783bf59d9b6753790c89e98",
+        "5783bf5ed9b6753790c89e99",
+        "5783bf62d9b6753790c89e9a"
+    ],
+    "set_root": true,
+    "en": {
+        "item_name": "Agkuza Set",
+        "description": "<p>This weapon deals primarily  Puncture damage.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Agkuza",
+        "drop": []
+    },
+    "ru": {
+        "item_name": "Агкуза Комплект",
+        "description": "<p>Разрывайте врагов на части с этим массивным клинком с крюком</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%90%D0%B3%D0%BA%D1%83%D0%B7%D0%B0",
+        "drop": []
+    },
+    "ko": {
+        "item_name": "악쿠자 세트",
+        "description": "<p>This weapon deals primarily  Puncture damage.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Agkuza",
+        "drop": []
+    },
+    "mastery_level": 0,
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Avenging Truth.json
+++ b/queued_updates/items/Avenging Truth.json
@@ -1,0 +1,62 @@
+{
+    "_id": "5911f11d97a0add8e9d5da51",
+    "tags": [
+        "mod",
+        "silva & aegis"
+    ],
+    "icon": "icons/en/Avenging_Truth.78f187d18567a17c8f76d1c8cdbd5ef3.png",
+    "thumb": "icons/en/thumbs/Avenging_Truth.78f187d18567a17c8f76d1c8cdbd5ef3.128x128.png",
+    "icon_format": "port",
+    "url_name": "avenging_truth",
+    "tradable": true,
+    "en": {
+        "item_name": "Avenging Truth",
+        "description": "<p>Avenging Truth allows Silva & Aegis to absorb a percentage of incoming damage while blocking. Damage absorbed this way will be stored as extra damage for the next charge attack. It also adds a Truth effect.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Avenging_Truth",
+        "drop": [
+            {
+                "name": "Operation: Ambulas Reborn",
+                "link": null
+            },
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Мстительная Правда",
+        "description": "<p>Мод-Аугмент для оружия Сильва и Эгида, который накапливает заблокированный урон и усиливает заряженную атаку. Даёт прирост синдикат-эффекта — Правда.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%9C%D1%81%D1%82%D0%B8%D1%82%D0%B5%D0%BB%D1%8C%D0%BD%D0%B0%D1%8F_%D0%9F%D1%80%D0%B0%D0%B2%D0%B4%D0%B0",
+        "icon": "icons/ru/Avenging_Truth.846efa48a583a2ca0bfa03f04728896b.png",
+        "thumb": "icons/ru/thumbs/Avenging_Truth.846efa48a583a2ca0bfa03f04728896b.128x128.png",
+        "drop": [
+            {
+                "name": "Operation: Ambulas Reborn",
+                "link": null
+            },
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "어벤징 트루스",
+        "description": "<p>Avenging Truth allows Silva & Aegis to absorb a percentage of incoming damage while blocking. Damage absorbed this way will be stored as extra damage for the next charge attack. It also adds a Truth effect.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Avenging_Truth",
+        "drop": [
+            {
+                "name": "Operation: Ambulas Reborn",
+                "link": null
+            },
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            }
+        ]
+    },
+    "rarity": "rare",
+    "mod_max_rank": 3,
+    "trading_tax": 8000
+}

--- a/queued_updates/items/Blade of Truth.json
+++ b/queued_updates/items/Blade of Truth.json
@@ -1,0 +1,51 @@
+{
+    "_id": "54a74454e779892d5e515645",
+    "tags": [
+        "weapons",
+        "mod",
+        "rare"
+    ],
+    "icon": "icons/en/Blade_of_Truth.53d68caa8f7ae06642b2ed1fd8f3b6cd.png",
+    "thumb": "icons/en/thumbs/Blade_of_Truth.53d68caa8f7ae06642b2ed1fd8f3b6cd.128x128.png",
+    "icon_format": "port",
+    "url_name": "blade_of_truth",
+    "tradable": true,
+    "en": {
+        "item_name": "Blade of Truth",
+        "description": "<p>The Blade of Truth mod is a Weapon Augment Mod that increases melee damage and Truth specifically for the Jaw Sword. It increases melee damage by 25% and Truth by 0.25 per rank, at a maximum of 100% and 1 at rank 3, respectively.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Blade_of_Truth",
+        "drop": [
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Клинок правды",
+        "description": "<p>Клинок Правды — мод-аугмент для оружия Меч-Челюсть, который  увеличивает урон и даёт прирост Синдикат-эффекта - Правда.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%9A%D0%BB%D0%B8%D0%BD%D0%BE%D0%BA_%D0%BF%D1%80%D0%B0%D0%B2%D0%B4%D1%8B",
+        "icon": "icons/ru/Blade_of_Truth.ec5d8d3a9200cb4e31f4269d60a676b4.png",
+        "thumb": "icons/ru/thumbs/Blade_of_Truth.ec5d8d3a9200cb4e31f4269d60a676b4.128x128.png",
+        "drop": [
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "블레이드 오브 트루스",
+        "description": "<p>The Blade of Truth mod is a Weapon Augment Mod that increases melee damage and Truth specifically for the Jaw Sword. It increases melee damage by 25% and Truth by 0.25 per rank, at a maximum of 100% and 1 at rank 3, respectively.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Blade_of_Truth",
+        "drop": [
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            }
+        ]
+    },
+    "rarity": "rare",
+    "mod_max_rank": 3,
+    "trading_tax": 8000
+}

--- a/queued_updates/items/Blinding Reave.json
+++ b/queued_updates/items/Blinding Reave.json
@@ -1,0 +1,63 @@
+{
+    "_id": "5cb04868fc2db2068006980c",
+    "tags": [
+        "mod",
+        "rare",
+        "revenant"
+    ],
+    "icon": "icons/en/Blinding_Reave.bc2092c3e7d7e1a2e48e64bee12547cd.png",
+    "thumb": "icons/en/thumbs/Blinding_Reave.bc2092c3e7d7e1a2e48e64bee12547cd.128x128.png",
+    "icon_format": "port",
+    "url_name": "blinding_reave",
+    "tradable": true,
+    "en": {
+        "item_name": "Blinding Reave",
+        "description": "<p>Blinding Reave is a Warframe Augment Mod for Revenant that blinds enemies caught in Reave's fog.</p>",
+        "wiki_link": "https://warframe.fandom.com/wiki/Blinding_Reave",
+        "drop": [
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            },
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Ослепляющее Опустошение",
+        "description": "<p>Ослепляющее Опустошение — мод-аугмент для Варфрейма Ревенант, изменяющий способность Опустошение. Задеты способностью противники будут ослеплены на небольшой промежуток времени.</p>",
+        "wiki_link": "https://warframe.fandom.com/ru/wiki/%D0%9E%D1%81%D0%BB%D0%B5%D0%BF%D0%BB%D1%8F%D1%8E%D1%89%D0%B5%D0%B5_%D0%9E%D0%BF%D1%83%D1%81%D1%82%D0%BE%D1%88%D0%B5%D0%BD%D0%B8%D0%B5",
+        "icon": "icons/ru/Blinding_Reave.0d5bc8ceb7258d41a1b541a35682f276.png",
+        "thumb": "icons/ru/thumbs/Blinding_Reave.0d5bc8ceb7258d41a1b541a35682f276.128x128.png",
+        "drop": [
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            },
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "블라인딩 리브",
+        "description": "<p>Blinding Reave is a Warframe Augment Mod for Revenant that blinds enemies caught in Reave's fog.</p>",
+        "wiki_link": "https://warframe.fandom.com/wiki/Blinding_Reave",
+        "drop": [
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            },
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "rarity": "rare",
+    "mod_max_rank": 3,
+    "trading_tax": 8000
+}

--- a/queued_updates/items/Bright Purity.json
+++ b/queued_updates/items/Bright Purity.json
@@ -1,0 +1,51 @@
+{
+    "_id": "54a74454e779892d5e51568a",
+    "tags": [
+        "mod",
+        "weapons",
+        "rare"
+    ],
+    "icon": "icons/en/Bright_Purity.3efd8f002eda7453eaa2672792b613fc.png",
+    "thumb": "icons/en/thumbs/Bright_Purity.3efd8f002eda7453eaa2672792b613fc.128x128.png",
+    "icon_format": "port",
+    "url_name": "bright_purity",
+    "tradable": true,
+    "en": {
+        "item_name": "Bright Purity",
+        "description": "<p>The Bright Purity mod is a Weapon Augment Mod that increases melee damage and Purity specifically for the Skana, Prisma Skana and Skana Prime. It increases melee damage by 25% and Purity by 0.25 per rank, at a maximum of 100% and 1 at rank 3, respectively.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Bright_Purity",
+        "drop": [
+            {
+                "name": "New Loka",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Яркая чистота",
+        "description": "<p>Яркая Чистота — мод-аугмент для оружия ближнего боя Скана, который увеличивает базовый урон и даёт прирост Синдикат-эффекта - Чистота.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%AF%D1%80%D0%BA%D0%B0%D1%8F_%D1%87%D0%B8%D1%81%D1%82%D0%BE%D1%82%D0%B0",
+        "icon": "icons/ru/Bright_Purity.548b4c2fb498686762a105b4b5c9f556.png",
+        "thumb": "icons/ru/thumbs/Bright_Purity.548b4c2fb498686762a105b4b5c9f556.128x128.png",
+        "drop": [
+            {
+                "name": "New Loka",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "브라이트 퓨리티",
+        "description": "<p>The Bright Purity mod is a Weapon Augment Mod that increases melee damage and Purity specifically for the Skana, Prisma Skana and Skana Prime. It increases melee damage by 25% and Purity by 0.25 per rank, at a maximum of 100% and 1 at rank 3, respectively.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Bright_Purity",
+        "drop": [
+            {
+                "name": "New Loka",
+                "link": null
+            }
+        ]
+    },
+    "rarity": "rare",
+    "mod_max_rank": 3,
+    "trading_tax": 8000
+}

--- a/queued_updates/items/Centaur Aegis.json
+++ b/queued_updates/items/Centaur Aegis.json
@@ -1,0 +1,54 @@
+{
+    "_id": "5783bf45d9b6753790c89e94",
+    "tags": [
+        "blueprint",
+        "archwing"
+    ],
+    "icon": "icons/en/Centaur_Set.7365135b7b3831714b657721d6b1df22.png",
+    "thumb": "icons/en/thumbs/Centaur_Set.7365135b7b3831714b657721d6b1df22.128x128.png",
+    "icon_format": "land",
+    "sub_icon": "sub_icons/generic_aegis_128x128.png",
+    "url_name": "centaur_aegis",
+    "tradable": true,
+    "part_of_set": [
+        "582b0f870af25410b099f7fc",
+        "5783bf45d9b6753790c89e94",
+        "5783bf41d9b6753790c89e93",
+        "5783bf4ad9b6753790c89e95"
+    ],
+    "set_root": false,
+    "en": {
+        "item_name": "Centaur Aegis",
+        "description": "<p>The Centaur is an Archwing based melee that also acts as a shield, which shares its own basic six-hit combo with Rathbone, but also possesses its own six-hit combo when used in quick melee (primary weapon equipped).</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Centaur",
+        "drop": [
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Кентавр Эгида",
+        "description": "<p>Частично меч, частично щит, Кентавр отлично показывает себя в безбашенных атаках под вражеским огнем</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%9A%D0%B5%D0%BD%D1%82%D0%B0%D0%B2%D1%80",
+        "drop": [
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "센타우르 이지스",
+        "description": "<p>The Centaur is an Archwing based melee that also acts as a shield, which shares its own basic six-hit combo with Rathbone, but also possesses its own six-hit combo when used in quick melee (primary weapon equipped).</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Centaur",
+        "drop": [
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            }
+        ]
+    },
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Centaur Blade.json
+++ b/queued_updates/items/Centaur Blade.json
@@ -1,0 +1,55 @@
+{
+    "_id": "5783bf41d9b6753790c89e93",
+    "tags": [
+        "parts",
+        "archwing",
+        "blade"
+    ],
+    "icon": "icons/en/Centaur_Set.7365135b7b3831714b657721d6b1df22.png",
+    "thumb": "icons/en/thumbs/Centaur_Set.7365135b7b3831714b657721d6b1df22.128x128.png",
+    "icon_format": "land",
+    "sub_icon": "sub_icons/blade_128x128.png",
+    "url_name": "centaur_blade",
+    "tradable": true,
+    "part_of_set": [
+        "582b0f870af25410b099f7fc",
+        "5783bf45d9b6753790c89e94",
+        "5783bf41d9b6753790c89e93",
+        "5783bf4ad9b6753790c89e95"
+    ],
+    "set_root": false,
+    "en": {
+        "item_name": "Centaur Blade",
+        "description": "<p>The Centaur is an Archwing based melee that also acts as a shield, which shares its own basic six-hit combo with Rathbone, but also possesses its own six-hit combo when used in quick melee (primary weapon equipped).</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Centaur",
+        "drop": [
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Кентавр Клинок",
+        "description": "<p>Частично меч, частично щит, Кентавр отлично показывает себя в безбашенных атаках под вражеским огнем</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%9A%D0%B5%D0%BD%D1%82%D0%B0%D0%B2%D1%80",
+        "drop": [
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "센타우르 블레이드",
+        "description": "<p>The Centaur is an Archwing based melee that also acts as a shield, which shares its own basic six-hit combo with Rathbone, but also possesses its own six-hit combo when used in quick melee (primary weapon equipped).</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Centaur",
+        "drop": [
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Centaur Handle.json
+++ b/queued_updates/items/Centaur Handle.json
@@ -1,0 +1,55 @@
+{
+    "_id": "5783bf4ad9b6753790c89e95",
+    "tags": [
+        "parts",
+        "archwing",
+        "handle"
+    ],
+    "icon": "icons/en/Centaur_Set.7365135b7b3831714b657721d6b1df22.png",
+    "thumb": "icons/en/thumbs/Centaur_Set.7365135b7b3831714b657721d6b1df22.128x128.png",
+    "icon_format": "land",
+    "sub_icon": "sub_icons/handle_128x128.png",
+    "url_name": "centaur_handle",
+    "tradable": true,
+    "part_of_set": [
+        "582b0f870af25410b099f7fc",
+        "5783bf45d9b6753790c89e94",
+        "5783bf41d9b6753790c89e93",
+        "5783bf4ad9b6753790c89e95"
+    ],
+    "set_root": false,
+    "en": {
+        "item_name": "Centaur Handle",
+        "description": "<p>The Centaur is an Archwing based melee that also acts as a shield, which shares its own basic six-hit combo with Rathbone, but also possesses its own six-hit combo when used in quick melee (primary weapon equipped).</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Centaur",
+        "drop": [
+            {
+                "name": "New Loka",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Кентавр Рукоять",
+        "description": "<p>Частично меч, частично щит, Кентавр отлично показывает себя в безбашенных атаках под вражеским огнем</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%9A%D0%B5%D0%BD%D1%82%D0%B0%D0%B2%D1%80",
+        "drop": [
+            {
+                "name": "New Loka",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "센타우르 핸들",
+        "description": "<p>The Centaur is an Archwing based melee that also acts as a shield, which shares its own basic six-hit combo with Rathbone, but also possesses its own six-hit combo when used in quick melee (primary weapon equipped).</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Centaur",
+        "drop": [
+            {
+                "name": "New Loka",
+                "link": null
+            }
+        ]
+    },
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Centaur Set.json
+++ b/queued_updates/items/Centaur Set.json
@@ -1,0 +1,39 @@
+{
+    "_id": "582b0f870af25410b099f7fc",
+    "tags": [
+        "parts",
+        "archwing",
+        "set"
+    ],
+    "icon": "icons/en/Centaur_Set.7365135b7b3831714b657721d6b1df22.png",
+    "thumb": "icons/en/thumbs/Centaur_Set.7365135b7b3831714b657721d6b1df22.128x128.png",
+    "icon_format": "land",
+    "url_name": "centaur_set",
+    "tradable": true,
+    "part_of_set": [
+        "582b0f870af25410b099f7fc",
+        "5783bf45d9b6753790c89e94",
+        "5783bf41d9b6753790c89e93",
+        "5783bf4ad9b6753790c89e95"
+    ],
+    "set_root": true,
+    "en": {
+        "item_name": "Centaur Set",
+        "description": "<p>The Centaur is an Archwing based melee that also acts as a shield, which shares its own basic six-hit combo with Rathbone, but also possesses its own six-hit combo when used in quick melee (primary weapon equipped).</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Centaur",
+        "drop": []
+    },
+    "ru": {
+        "item_name": "Кентавр Комплект",
+        "description": "<p>Частично меч, частично щит, Кентавр отлично показывает себя в безбашенных атаках под вражеским огнем</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%9A%D0%B5%D0%BD%D1%82%D0%B0%D0%B2%D1%80",
+        "drop": []
+    },
+    "ko": {
+        "item_name": "센타우르 세트",
+        "description": "<p>The Centaur is an Archwing based melee that also acts as a shield, which shares its own basic six-hit combo with Rathbone, but also possesses its own six-hit combo when used in quick melee (primary weapon equipped).</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Centaur",
+        "drop": []
+    },
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Corpus Gas City Conduit Scene.json
+++ b/queued_updates/items/Corpus Gas City Conduit Scene.json
@@ -1,0 +1,45 @@
+{
+    "_id": "5a9e8670b2b6a800db67f126",
+    "tags": [
+        "scene"
+    ],
+    "icon": "icons/en/Corpus_Gas_City_Conduit_Scene.f3696ad7d670f8228acf03032758f902.png",
+    "thumb": "icons/en/thumbs/Corpus_Gas_City_Conduit_Scene.f3696ad7d670f8228acf03032758f902.128x128.png",
+    "icon_format": "land",
+    "url_name": "corpus_gas_city_conduit_scene",
+    "tradable": true,
+    "en": {
+        "item_name": "Corpus Gas City Conduit Scene",
+        "description": "<p>Captura is an image capture and editing tool that allows players to manipulate and compose scenarios for screenshots.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Captura",
+        "drop": [
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Corpus Gas City Conduit Scene",
+        "description": "<p>Специальный режим, позволяющий делать красочные снимки.<br/>Для использования режима необходимо войти во Внешний вид и нажать Каптура.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%9A%D0%B0%D0%BF%D1%82%D1%83%D1%80%D0%B0",
+        "drop": [
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "코퍼스 가스 도시 도관 배경",
+        "description": "<p>Captura is an image capture and editing tool that allows players to manipulate and compose scenarios for screenshots.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Captura",
+        "drop": [
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Corroding Barrage.json
+++ b/queued_updates/items/Corroding Barrage.json
@@ -1,0 +1,62 @@
+{
+    "_id": "58446f502c2ada0042b6fc3d",
+    "tags": [
+        "mod",
+        "warframe",
+        "rare",
+        "hydroid"
+    ],
+    "icon": "icons/en/Corroding_Barrage.98840ac4923a0115b6d43b24f745e34e.png",
+    "thumb": "icons/en/thumbs/Corroding_Barrage.98840ac4923a0115b6d43b24f745e34e.128x128.png",
+    "icon_format": "port",
+    "url_name": "corroding_barrage",
+    "tradable": true,
+    "en": {
+        "item_name": "Corroding Barrage",
+        "description": "<p>Corroding Barrage is a Warframe Augment Mod for Hydroid where each projectile of Tempest Barrage has a percent chance of inflicting a Corrosive b Corrosive status effect.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Corroding_Barrage",
+        "drop": [
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            },
+            {
+                "name": "New Loka",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Коррозийный Шквал",
+        "description": "<p>Каждый снаряд имеет 100% шанс нанести эффект статуса Коррозии.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/Коррозийный_Шквал",
+        "drop": [
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            },
+            {
+                "name": "New Loka",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "코로딩 배러지",
+        "description": "<p>Corroding Barrage is a Warframe Augment Mod for Hydroid where each projectile of Tempest Barrage has a percent chance of inflicting a Corrosive b Corrosive status effect.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Corroding_Barrage",
+        "drop": [
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            },
+            {
+                "name": "New Loka",
+                "link": null
+            }
+        ]
+    },
+    "rarity": "rare",
+    "mod_max_rank": 3,
+    "trading_tax": 8000
+}

--- a/queued_updates/items/Corvas Barrel.json
+++ b/queued_updates/items/Corvas Barrel.json
@@ -1,0 +1,55 @@
+{
+    "_id": "578d33bf34003bbbb9e20921",
+    "tags": [
+        "parts",
+        "archwing",
+        "barrel"
+    ],
+    "icon": "icons/en/Corvas_Set.0248b2ad006d7ad6a460cc03eac4baa7.png",
+    "thumb": "icons/en/thumbs/Corvas_Set.0248b2ad006d7ad6a460cc03eac4baa7.128x128.png",
+    "icon_format": "land",
+    "sub_icon": "sub_icons/barrel_128x128.png",
+    "url_name": "corvas_barrel",
+    "tradable": true,
+    "part_of_set": [
+        "582b0f890af25410b099f7ff",
+        "578d33bf34003bbbb9e20921",
+        "578d33bf34003bbbb9e20922",
+        "578d33bf34003bbbb9e20923"
+    ],
+    "set_root": false,
+    "en": {
+        "item_name": "Corvas Barrel",
+        "description": "<p>The Corvas flak cannon is a heavy shotgun designed for exclusive use with the Archwing flight system, introduced in Update 15.0. It can be rapidly fired to saturate an area with pellets, or charged to release a more powerful scattershot.  </p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Corvas",
+        "drop": [
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Корвас Ствол",
+        "description": "<p>Полностью заряженная эта осколочная пушка наносит огромный урон. Идеально подходил для уничтожения быстродвижущихся перехватчиков.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%9A%D0%BE%D1%80%D0%B2%D0%B0%D1%81",
+        "drop": [
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "코르바스 배럴",
+        "description": "<p>The Corvas flak cannon is a heavy shotgun designed for exclusive use with the Archwing flight system, introduced in Update 15.0. It can be rapidly fired to saturate an area with pellets, or charged to release a more powerful scattershot.  </p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Corvas",
+        "drop": [
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            }
+        ]
+    },
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Corvas Receiver.json
+++ b/queued_updates/items/Corvas Receiver.json
@@ -1,0 +1,55 @@
+{
+    "_id": "578d33bf34003bbbb9e20922",
+    "tags": [
+        "parts",
+        "archwing",
+        "receiver"
+    ],
+    "icon": "icons/en/Corvas_Set.0248b2ad006d7ad6a460cc03eac4baa7.png",
+    "thumb": "icons/en/thumbs/Corvas_Set.0248b2ad006d7ad6a460cc03eac4baa7.128x128.png",
+    "icon_format": "land",
+    "sub_icon": "sub_icons/receiver_128x128.png",
+    "url_name": "corvas_receiver",
+    "tradable": true,
+    "part_of_set": [
+        "582b0f890af25410b099f7ff",
+        "578d33bf34003bbbb9e20921",
+        "578d33bf34003bbbb9e20922",
+        "578d33bf34003bbbb9e20923"
+    ],
+    "set_root": false,
+    "en": {
+        "item_name": "Corvas Receiver",
+        "description": "<p>The Corvas flak cannon is a heavy shotgun designed for exclusive use with the Archwing flight system, introduced in Update 15.0. It can be rapidly fired to saturate an area with pellets, or charged to release a more powerful scattershot.  </p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Corvas",
+        "drop": [
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Корвас Приемник",
+        "description": "<p>Полностью заряженная эта осколочная пушка наносит огромный урон. Идеально подходил для уничтожения быстродвижущихся перехватчиков.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%9A%D0%BE%D1%80%D0%B2%D0%B0%D1%81",
+        "drop": [
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "코르바스 리시버",
+        "description": "<p>The Corvas flak cannon is a heavy shotgun designed for exclusive use with the Archwing flight system, introduced in Update 15.0. It can be rapidly fired to saturate an area with pellets, or charged to release a more powerful scattershot.  </p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Corvas",
+        "drop": [
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            }
+        ]
+    },
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Corvas Set.json
+++ b/queued_updates/items/Corvas Set.json
@@ -1,0 +1,39 @@
+{
+    "_id": "582b0f890af25410b099f7ff",
+    "tags": [
+        "parts",
+        "archwing",
+        "set"
+    ],
+    "icon": "icons/en/Corvas_Set.0248b2ad006d7ad6a460cc03eac4baa7.png",
+    "thumb": "icons/en/thumbs/Corvas_Set.0248b2ad006d7ad6a460cc03eac4baa7.128x128.png",
+    "icon_format": "land",
+    "url_name": "corvas_set",
+    "tradable": true,
+    "part_of_set": [
+        "582b0f890af25410b099f7ff",
+        "578d33bf34003bbbb9e20921",
+        "578d33bf34003bbbb9e20922",
+        "578d33bf34003bbbb9e20923"
+    ],
+    "set_root": true,
+    "en": {
+        "item_name": "Corvas Set",
+        "description": "<p>The Corvas flak cannon is a heavy shotgun designed for exclusive use with the Archwing flight system, introduced in Update 15.0. It can be rapidly fired to saturate an area with pellets, or charged to release a more powerful scattershot.  </p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Corvas",
+        "drop": []
+    },
+    "ru": {
+        "item_name": "Корвас Комплект",
+        "description": "<p>Полностью заряженная эта осколочная пушка наносит огромный урон. Идеально подходил для уничтожения быстродвижущихся перехватчиков.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%9A%D0%BE%D1%80%D0%B2%D0%B0%D1%81",
+        "drop": []
+    },
+    "ko": {
+        "item_name": "코르바스 세트",
+        "description": "<p>The Corvas flak cannon is a heavy shotgun designed for exclusive use with the Archwing flight system, introduced in Update 15.0. It can be rapidly fired to saturate an area with pellets, or charged to release a more powerful scattershot.  </p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Corvas",
+        "drop": []
+    },
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Corvas Stock.json
+++ b/queued_updates/items/Corvas Stock.json
@@ -1,0 +1,55 @@
+{
+    "_id": "578d33bf34003bbbb9e20923",
+    "tags": [
+        "parts",
+        "archwing",
+        "stock"
+    ],
+    "icon": "icons/en/Corvas_Set.0248b2ad006d7ad6a460cc03eac4baa7.png",
+    "thumb": "icons/en/thumbs/Corvas_Set.0248b2ad006d7ad6a460cc03eac4baa7.128x128.png",
+    "icon_format": "land",
+    "sub_icon": "sub_icons/stock_128x128.png",
+    "url_name": "corvas_stock",
+    "tradable": true,
+    "part_of_set": [
+        "582b0f890af25410b099f7ff",
+        "578d33bf34003bbbb9e20921",
+        "578d33bf34003bbbb9e20922",
+        "578d33bf34003bbbb9e20923"
+    ],
+    "set_root": false,
+    "en": {
+        "item_name": "Corvas Stock",
+        "description": "<p>The Corvas flak cannon is a heavy shotgun designed for exclusive use with the Archwing flight system, introduced in Update 15.0. It can be rapidly fired to saturate an area with pellets, or charged to release a more powerful scattershot.  </p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Corvas",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Корвас Приклад",
+        "description": "<p>Полностью заряженная эта осколочная пушка наносит огромный урон. Идеально подходил для уничтожения быстродвижущихся перехватчиков.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%9A%D0%BE%D1%80%D0%B2%D0%B0%D1%81",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "코르바스 스톡",
+        "description": "<p>The Corvas flak cannon is a heavy shotgun designed for exclusive use with the Archwing flight system, introduced in Update 15.0. It can be rapidly fired to saturate an area with pellets, or charged to release a more powerful scattershot.  </p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Corvas",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            }
+        ]
+    },
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Cyngas Barrel.json
+++ b/queued_updates/items/Cyngas Barrel.json
@@ -1,0 +1,56 @@
+{
+    "_id": "5783bf69d9b6753790c89e9b",
+    "tags": [
+        "parts",
+        "archwing",
+        "barrel"
+    ],
+    "icon": "icons/en/Cyngas_Set.5b9891a467264b6048cd58b409911767.png",
+    "thumb": "icons/en/thumbs/Cyngas_Set.5b9891a467264b6048cd58b409911767.128x128.png",
+    "icon_format": "land",
+    "sub_icon": "sub_icons/barrel_128x128.png",
+    "url_name": "cyngas_barrel",
+    "tradable": true,
+    "part_of_set": [
+        "58284d9f0af2540aa8de3495",
+        "5783bf69d9b6753790c89e9b",
+        "5783bf6dd9b6753790c89e9c",
+        "5783bf71d9b6753790c89e9d"
+    ],
+    "set_root": false,
+    "en": {
+        "item_name": "Cyngas Barrel",
+        "description": "<p>This weapon deals primarily  Slash damage by a small margin</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Cyngas",
+        "drop": [
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Цингас Ствол",
+        "description": "<p>Наносите увечья смертельно точными очередями.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%A6%D0%B8%D0%BD%D0%B3%D0%B0%D1%81",
+        "drop": [
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "싱가스 배럴",
+        "description": "<p>This weapon deals primarily  Slash damage by a small margin</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Cyngas",
+        "drop": [
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            }
+        ]
+    },
+    "mastery_level": 4,
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Cyngas Receiver.json
+++ b/queued_updates/items/Cyngas Receiver.json
@@ -1,0 +1,56 @@
+{
+    "_id": "5783bf6dd9b6753790c89e9c",
+    "tags": [
+        "parts",
+        "archwing",
+        "receiver"
+    ],
+    "icon": "icons/en/Cyngas_Set.5b9891a467264b6048cd58b409911767.png",
+    "thumb": "icons/en/thumbs/Cyngas_Set.5b9891a467264b6048cd58b409911767.128x128.png",
+    "icon_format": "land",
+    "sub_icon": "sub_icons/receiver_128x128.png",
+    "url_name": "cyngas_receiver",
+    "tradable": true,
+    "part_of_set": [
+        "58284d9f0af2540aa8de3495",
+        "5783bf69d9b6753790c89e9b",
+        "5783bf6dd9b6753790c89e9c",
+        "5783bf71d9b6753790c89e9d"
+    ],
+    "set_root": false,
+    "en": {
+        "item_name": "Cyngas Receiver",
+        "description": "<p>This weapon deals primarily  Slash damage by a small margin</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Cyngas",
+        "drop": [
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Цингас Приемник",
+        "description": "<p>Наносите увечья смертельно точными очередями.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%A6%D0%B8%D0%BD%D0%B3%D0%B0%D1%81",
+        "drop": [
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "싱가스 리시버",
+        "description": "<p>This weapon deals primarily  Slash damage by a small margin</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Cyngas",
+        "drop": [
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            }
+        ]
+    },
+    "mastery_level": 4,
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Cyngas Stock.json
+++ b/queued_updates/items/Cyngas Stock.json
@@ -1,0 +1,56 @@
+{
+    "_id": "5783bf71d9b6753790c89e9d",
+    "tags": [
+        "parts",
+        "archwing",
+        "stock"
+    ],
+    "icon": "icons/en/Cyngas_Set.5b9891a467264b6048cd58b409911767.png",
+    "thumb": "icons/en/thumbs/Cyngas_Set.5b9891a467264b6048cd58b409911767.128x128.png",
+    "icon_format": "land",
+    "sub_icon": "sub_icons/stock_128x128.png",
+    "url_name": "cyngas_stock",
+    "tradable": true,
+    "part_of_set": [
+        "58284d9f0af2540aa8de3495",
+        "5783bf69d9b6753790c89e9b",
+        "5783bf6dd9b6753790c89e9c",
+        "5783bf71d9b6753790c89e9d"
+    ],
+    "set_root": false,
+    "en": {
+        "item_name": "Cyngas Stock",
+        "description": "<p>This weapon deals primarily  Slash damage by a small margin</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Cyngas",
+        "drop": [
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Цингас Приклад",
+        "description": "<p>Наносите увечья смертельно точными очередями.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%A6%D0%B8%D0%BD%D0%B3%D0%B0%D1%81",
+        "drop": [
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "싱가스 스톡",
+        "description": "<p>This weapon deals primarily  Slash damage by a small margin</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Cyngas",
+        "drop": [
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "mastery_level": 4,
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Deadly Sequence.json
+++ b/queued_updates/items/Deadly Sequence.json
@@ -1,0 +1,51 @@
+{
+    "_id": "54a74454e779892d5e515666",
+    "tags": [
+        "mod",
+        "weapons",
+        "rare"
+    ],
+    "icon": "icons/en/Deadly_Sequence.da21893bc4cd1e2eea7a73044479c148.png",
+    "thumb": "icons/en/thumbs/Deadly_Sequence.da21893bc4cd1e2eea7a73044479c148.128x128.png",
+    "icon_format": "port",
+    "url_name": "deadly_sequence",
+    "tradable": true,
+    "en": {
+        "item_name": "Deadly Sequence",
+        "description": "<p>The Deadly Sequence mod is a Weapon Augment Mod that increases critical chance and Sequence specifically for the Grinlok. It increases critical chance by 50% and Sequence by 0.25 per rank, at a maximum of 200% and 1 at rank 3, respectively.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Deadly_Sequence",
+        "drop": [
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Смертельная последовательность",
+        "description": "<p>Смертельная Последовательность — мод-аугмент для винтовки Гринлок, который увеличивает шанс критического урона на 50%, а также даёт прирост Последовательности в размере 0.25. На максимальном ранге мода бонус к шансу критического урона составляет 200%, а прирост Последовательности увеличен до 1.0.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%A1%D0%BC%D0%B5%D1%80%D1%82%D0%B5%D0%BB%D1%8C%D0%BD%D0%B0%D1%8F_%D0%BF%D0%BE%D1%81%D0%BB%D0%B5%D0%B4%D0%BE%D0%B2%D0%B0%D1%82%D0%B5%D0%BB%D1%8C%D0%BD%D0%BE%D1%81%D1%82%D1%8C",
+        "icon": "icons/ru/Deadly_Sequence.435f4898759ec050c3681c60968379b8.png",
+        "thumb": "icons/ru/thumbs/Deadly_Sequence.435f4898759ec050c3681c60968379b8.128x128.png",
+        "drop": [
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "데들리 시퀀스",
+        "description": "<p>The Deadly Sequence mod is a Weapon Augment Mod that increases critical chance and Sequence specifically for the Grinlok. It increases critical chance by 50% and Sequence by 0.25 per rank, at a maximum of 200% and 1 at rank 3, respectively.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Deadly_Sequence",
+        "drop": [
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "rarity": "rare",
+    "mod_max_rank": 3,
+    "trading_tax": 8000
+}

--- a/queued_updates/items/Decurion Barrel.json
+++ b/queued_updates/items/Decurion Barrel.json
@@ -1,0 +1,54 @@
+{
+    "_id": "5783bf27d9b6753790c89e8e",
+    "tags": [
+        "parts",
+        "archwing",
+        "barrel"
+    ],
+    "icon": "icons/en/Decurion_Set.5682bc698e5481541faba69246a2c248.png",
+    "thumb": "icons/en/thumbs/Decurion_Set.5682bc698e5481541faba69246a2c248.128x128.png",
+    "icon_format": "land",
+    "sub_icon": "sub_icons/barrel_128x128.png",
+    "url_name": "decurion_barrel",
+    "tradable": true,
+    "part_of_set": [
+        "582b0f860af25410b099f7fa",
+        "5783bf27d9b6753790c89e8e",
+        "5783bf2dd9b6753790c89e8f"
+    ],
+    "set_root": false,
+    "en": {
+        "item_name": "Decurion Barrel",
+        "description": "<p>The Dual Decurion are twin rifles exclusive to the Archwing flight system.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Dual_Decurion",
+        "drop": [
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Декурион Ствол",
+        "description": "<p>Использующие два потока высокоточного огня, Декурионы были разработаны специально для ведения боя в безвоздушном пространстве.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%9F%D0%B0%D1%80%D0%BD%D1%8B%D0%B9_%D0%B4%D0%B5%D0%BA%D1%83%D1%80%D0%B8%D0%BE%D0%BD",
+        "drop": [
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "데큐리온 배럴",
+        "description": "<p>The Dual Decurion are twin rifles exclusive to the Archwing flight system.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Dual_Decurion",
+        "drop": [
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            }
+        ]
+    },
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Decurion Receiver.json
+++ b/queued_updates/items/Decurion Receiver.json
@@ -1,0 +1,54 @@
+{
+    "_id": "5783bf2dd9b6753790c89e8f",
+    "tags": [
+        "parts",
+        "archwing",
+        "receiver"
+    ],
+    "icon": "icons/en/Decurion_Set.5682bc698e5481541faba69246a2c248.png",
+    "thumb": "icons/en/thumbs/Decurion_Set.5682bc698e5481541faba69246a2c248.128x128.png",
+    "icon_format": "land",
+    "sub_icon": "sub_icons/receiver_128x128.png",
+    "url_name": "decurion_receiver",
+    "tradable": true,
+    "part_of_set": [
+        "582b0f860af25410b099f7fa",
+        "5783bf27d9b6753790c89e8e",
+        "5783bf2dd9b6753790c89e8f"
+    ],
+    "set_root": false,
+    "en": {
+        "item_name": "Decurion Receiver",
+        "description": "<p>The Dual Decurion are twin rifles exclusive to the Archwing flight system.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Dual_Decurion",
+        "drop": [
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Декурион Приемник",
+        "description": "<p>Использующие два потока высокоточного огня, Декурионы были разработаны специально для ведения боя в безвоздушном пространстве.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%9F%D0%B0%D1%80%D0%BD%D1%8B%D0%B9_%D0%B4%D0%B5%D0%BA%D1%83%D1%80%D0%B8%D0%BE%D0%BD",
+        "drop": [
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "데큐리온 리시버",
+        "description": "<p>The Dual Decurion are twin rifles exclusive to the Archwing flight system.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Dual_Decurion",
+        "drop": [
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            }
+        ]
+    },
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Disarming Purity.json
+++ b/queued_updates/items/Disarming Purity.json
@@ -1,0 +1,62 @@
+{
+    "_id": "5911f11d97a0add8e9d5da4c",
+    "tags": [
+        "mod",
+        "panthera"
+    ],
+    "icon": "icons/en/Disarming_Purity.051b3489272e846e1ea5ecc351ea9c32.png",
+    "thumb": "icons/en/thumbs/Disarming_Purity.051b3489272e846e1ea5ecc351ea9c32.128x128.png",
+    "icon_format": "port",
+    "url_name": "disarming_purity",
+    "tradable": true,
+    "en": {
+        "item_name": "Disarming Purity",
+        "description": "<p>Disarming Purity gives the Panthera's secondary fire mode a 40% chance to disarm enemies. It also adds a Purity effect.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Disarming_Purity",
+        "drop": [
+            {
+                "name": "Operation: Ambulas Reborn",
+                "link": null
+            },
+            {
+                "name": "New Loka",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Обезоруживающая Чистота",
+        "description": "<p>Обезоруживающая Чистота — Мод-Аугмент для оружия Пантера, позволяющий альтернативной атакой обезоруживать врага и дающий прирост синдикат-эффекта — Чистота.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%9E%D0%B1%D0%B5%D0%B7%D0%BE%D1%80%D1%83%D0%B6%D0%B8%D0%B2%D0%B0%D1%8E%D1%89%D0%B0%D1%8F_%D0%A7%D0%B8%D1%81%D1%82%D0%BE%D1%82%D0%B0",
+        "icon": "icons/ru/Disarming_Purity.7ae5c50f08fb25f8d4bce9ce15e56269.png",
+        "thumb": "icons/ru/thumbs/Disarming_Purity.7ae5c50f08fb25f8d4bce9ce15e56269.128x128.png",
+        "drop": [
+            {
+                "name": "Operation: Ambulas Reborn",
+                "link": null
+            },
+            {
+                "name": "New Loka",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "디스아밍 퓨리티",
+        "description": "<p>Disarming Purity gives the Panthera's secondary fire mode a 40% chance to disarm enemies. It also adds a Purity effect.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Disarming_Purity",
+        "drop": [
+            {
+                "name": "Operation: Ambulas Reborn",
+                "link": null
+            },
+            {
+                "name": "New Loka",
+                "link": null
+            }
+        ]
+    },
+    "rarity": "rare",
+    "mod_max_rank": 3,
+    "trading_tax": 8000
+}

--- a/queued_updates/items/Dual Decurion Set.json
+++ b/queued_updates/items/Dual Decurion Set.json
@@ -1,0 +1,38 @@
+{
+    "_id": "582b0f860af25410b099f7fa",
+    "tags": [
+        "parts",
+        "archwing",
+        "set"
+    ],
+    "icon": "icons/en/Dual_Decurion_Set.5682bc698e5481541faba69246a2c248.png",
+    "thumb": "icons/en/thumbs/Dual_Decurion_Set.5682bc698e5481541faba69246a2c248.128x128.png",
+    "icon_format": "land",
+    "url_name": "dual_decurion_set",
+    "tradable": true,
+    "part_of_set": [
+        "582b0f860af25410b099f7fa",
+        "5783bf27d9b6753790c89e8e",
+        "5783bf2dd9b6753790c89e8f"
+    ],
+    "set_root": true,
+    "en": {
+        "item_name": "Dual Decurion Set",
+        "description": "<p>The Dual Decurion are twin rifles exclusive to the Archwing flight system.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Dual_Decurion",
+        "drop": []
+    },
+    "ru": {
+        "item_name": "Парный декурион Комплект",
+        "description": "<p>Использующие два потока высокоточного огня, Декурионы были разработаны специально для ведения боя в безвоздушном пространстве.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%9F%D0%B0%D1%80%D0%BD%D1%8B%D0%B9_%D0%B4%D0%B5%D0%BA%D1%83%D1%80%D0%B8%D0%BE%D0%BD",
+        "drop": []
+    },
+    "ko": {
+        "item_name": "듀얼 데큐리온 세트",
+        "description": "<p>The Dual Decurion are twin rifles exclusive to the Archwing flight system.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Dual_Decurion",
+        "drop": []
+    },
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Elemental Sandstorm.json
+++ b/queued_updates/items/Elemental Sandstorm.json
@@ -1,0 +1,63 @@
+{
+    "_id": "57c73be094b4b0f159ab5e14",
+    "tags": [
+        "mod",
+        "warframe",
+        "rare"
+    ],
+    "icon": "icons/en/Elemental_Sandstorm.5957557c1c7445897e7615c33d508a34.png",
+    "thumb": "icons/en/thumbs/Elemental_Sandstorm.5957557c1c7445897e7615c33d508a34.128x128.png",
+    "icon_format": "port",
+    "url_name": "elemental_sandstorm",
+    "tradable": true,
+    "en": {
+        "item_name": "Elemental Sandstorm",
+        "description": "<p>Elemental Sandstorm is a Warframe Augment Mod for Inaros that causes Sandstorm to inflict status procs based on equipped damage types and mods on melee weapons currently wielded.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Elemental_Sandstorm",
+        "drop": [
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            },
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Элементальная буря",
+        "description": "<p>Элементальная буря — мод-аугмент для варфрейма Инарос, улучшающий его способность песчаная буря. Буря имеет шанс нанести статусный эффект, зависящий от элементальных модов, которые установлены на оружии ближнего боя.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%AD%D0%BB%D0%B5%D0%BC%D0%B5%D0%BD%D1%82%D0%B0%D0%BB%D1%8C%D0%BD%D0%B0%D1%8F_%D0%B1%D1%83%D1%80%D1%8F",
+        "icon": "icons/ru/Elemental_Sandstorm.276ca86867f9ea5aff4edb51f00accca.png",
+        "thumb": "icons/ru/thumbs/Elemental_Sandstorm.276ca86867f9ea5aff4edb51f00accca.128x128.png",
+        "drop": [
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            },
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "엘레멘탈 샌드스톰",
+        "description": "<p>Elemental Sandstorm is a Warframe Augment Mod for Inaros that causes Sandstorm to inflict status procs based on equipped damage types and mods on melee weapons currently wielded.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Elemental_Sandstorm",
+        "drop": [
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            },
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "rarity": "rare",
+    "mod_max_rank": 3,
+    "trading_tax": 8000
+}

--- a/queued_updates/items/Entropy Burst.json
+++ b/queued_updates/items/Entropy Burst.json
@@ -1,0 +1,51 @@
+{
+    "_id": "54a74455e779892d5e5156a3",
+    "tags": [
+        "mod",
+        "weapons",
+        "rare"
+    ],
+    "icon": "icons/en/Entropy_Burst.66a8a280f2d56a5bdd29607869a147c3.png",
+    "thumb": "icons/en/thumbs/Entropy_Burst.66a8a280f2d56a5bdd29607869a147c3.128x128.png",
+    "icon_format": "port",
+    "url_name": "entropy_burst",
+    "tradable": true,
+    "en": {
+        "item_name": "Entropy Burst",
+        "description": "<p>The Entropy Burst mod is a Weapon Augment Mod that increases status chance and Entropy specifically for the Supra. It increases status chance by a flat +5 and Entropy by +0.25 per rank, at a maximum of +20 and 1 at rank 3, respectively.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Entropy_Burst",
+        "drop": [
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Энтропийный взрыв",
+        "description": "<p>Энтропийный Взрыв — мод-аугмент для оружия Супра, который увеличивает базовый шанс срабатывания эффекта статуса и даёт прирост Синдикат-эффекта - Энтропия .</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%AD%D0%BD%D1%82%D1%80%D0%BE%D0%BF%D0%B8%D0%B9%D0%BD%D1%8B%D0%B9_%D0%B2%D0%B7%D1%80%D1%8B%D0%B2",
+        "icon": "icons/ru/Entropy_Burst.8f1c3427f52de14dd0fd63c554bf27fe.png",
+        "thumb": "icons/ru/thumbs/Entropy_Burst.8f1c3427f52de14dd0fd63c554bf27fe.128x128.png",
+        "drop": [
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "엔트로피 버스트",
+        "description": "<p>The Entropy Burst mod is a Weapon Augment Mod that increases status chance and Entropy specifically for the Supra. It increases status chance by a flat +5 and Entropy by +0.25 per rank, at a maximum of +20 and 1 at rank 3, respectively.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Entropy_Burst",
+        "drop": [
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            }
+        ]
+    },
+    "rarity": "rare",
+    "mod_max_rank": 3,
+    "trading_tax": 8000
+}

--- a/queued_updates/items/Entropy Detonation.json
+++ b/queued_updates/items/Entropy Detonation.json
@@ -1,0 +1,62 @@
+{
+    "_id": "5911f11d97a0add8e9d5da50",
+    "tags": [
+        "mod",
+        "obex"
+    ],
+    "icon": "icons/en/Entropy_Detonation.2330a8de6cb887513a92da41f5ea4708.png",
+    "thumb": "icons/en/thumbs/Entropy_Detonation.2330a8de6cb887513a92da41f5ea4708.128x128.png",
+    "icon_format": "port",
+    "url_name": "entropy_detonation",
+    "tradable": true,
+    "en": {
+        "item_name": "Entropy Detonation",
+        "description": "<p>Entropy Detonation causes lethal ground finishers used by the Obex (or its Prisma variant) to cause enemies to explode, dealing damage to other nearby enemies. It also adds an Entropy effect.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Entropy_Detonation",
+        "drop": [
+            {
+                "name": "Operation: Ambulas Reborn",
+                "link": null
+            },
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Взрывная Энтропия",
+        "description": "<p>Взрывная Энтропия — Мод-Аугмент для оружия Обекс, который наносит Взрыв черный взрывной урон и дополнительно % от максимального здоровья врага и даёт прирост синдикат-эффекта — Энтропия.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%92%D0%B7%D1%80%D1%8B%D0%B2%D0%BD%D0%B0%D1%8F_%D0%AD%D0%BD%D1%82%D1%80%D0%BE%D0%BF%D0%B8%D1%8F",
+        "icon": "icons/ru/Entropy_Detonation.4cffb0a2b673cd51bde76a282e9bb775.png",
+        "thumb": "icons/ru/thumbs/Entropy_Detonation.4cffb0a2b673cd51bde76a282e9bb775.128x128.png",
+        "drop": [
+            {
+                "name": "Operation: Ambulas Reborn",
+                "link": null
+            },
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "엔트로피 디토네이션",
+        "description": "<p>Entropy Detonation causes lethal ground finishers used by the Obex (or its Prisma variant) to cause enemies to explode, dealing damage to other nearby enemies. It also adds an Entropy effect.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Entropy_Detonation",
+        "drop": [
+            {
+                "name": "Operation: Ambulas Reborn",
+                "link": null
+            },
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            }
+        ]
+    },
+    "rarity": "rare",
+    "mod_max_rank": 3,
+    "trading_tax": 8000
+}

--- a/queued_updates/items/Entropy Flight.json
+++ b/queued_updates/items/Entropy Flight.json
@@ -1,0 +1,51 @@
+{
+    "_id": "54a74454e779892d5e5155ee",
+    "tags": [
+        "mod",
+        "weapons",
+        "rare"
+    ],
+    "icon": "icons/en/Entropy_Flight.d0aac5dc51491213cff3e4ff49c9acff.png",
+    "thumb": "icons/en/thumbs/Entropy_Flight.d0aac5dc51491213cff3e4ff49c9acff.128x128.png",
+    "icon_format": "port",
+    "url_name": "entropy_flight",
+    "tradable": true,
+    "en": {
+        "item_name": "Entropy Flight",
+        "description": "<p>The Entropy Flight mod is a Weapon Augment Mod that increases flight speed and Entropy specifically for the Kestrel. It increases flight speed by 35% and Entropy by 0.25 per rank, at a maximum of 140% and 1 at rank 3, respectively.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Entropy_Flight",
+        "drop": [
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Полёт энтропии",
+        "description": "<p>Полёт Энтропии —мод-аугмент для оружия Кестрел, который увеличивает скорость полёта метательной атаки и даёт прирост Синдикат-эффекта - Энтропия.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%9F%D0%BE%D0%BB%D1%91%D1%82_%D1%8D%D0%BD%D1%82%D1%80%D0%BE%D0%BF%D0%B8%D0%B8",
+        "icon": "icons/ru/Entropy_Flight.0550a67f2ca90039302001b1c9092617.png",
+        "thumb": "icons/ru/thumbs/Entropy_Flight.0550a67f2ca90039302001b1c9092617.128x128.png",
+        "drop": [
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "엔트로피 플라이트",
+        "description": "<p>The Entropy Flight mod is a Weapon Augment Mod that increases flight speed and Entropy specifically for the Kestrel. It increases flight speed by 35% and Entropy by 0.25 per rank, at a maximum of 140% and 1 at rank 3, respectively.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Entropy_Flight",
+        "drop": [
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            }
+        ]
+    },
+    "rarity": "rare",
+    "mod_max_rank": 3,
+    "trading_tax": 8000
+}

--- a/queued_updates/items/Entropy Spike.json
+++ b/queued_updates/items/Entropy Spike.json
@@ -1,0 +1,51 @@
+{
+    "_id": "54a74454e779892d5e5155be",
+    "tags": [
+        "mod",
+        "weapons",
+        "rare"
+    ],
+    "icon": "icons/en/Entropy_Spike.def94f74a5e4438a695d47fb336d6066.png",
+    "thumb": "icons/en/thumbs/Entropy_Spike.def94f74a5e4438a695d47fb336d6066.128x128.png",
+    "icon_format": "port",
+    "url_name": "entropy_spike",
+    "tradable": true,
+    "en": {
+        "item_name": "Entropy Spike",
+        "description": "<p>The Entropy Spike mod is a Weapon Augment Mod that adds an explosion chance and Entropy specifically for the Bolto. It increases the explosion chance by 0.05 and Entropy by 0.25 per rank, at a maximum of 0.2 and 1 at rank 3, respectively. Explosions deal 250  Blast damage to the target, as well as to nearby enemies within 10 meters of the blast (scaled by distance).</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Entropy_Spike",
+        "drop": [
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Шип энтропии",
+        "description": "<p>Шип Энтропии — мод-аугмент для оружия Болто, который с некоторым шансом позволяет болтам оружия взрываться при соприкосновении и даёт прирост синдикат-эффекта - Энтропия. Радиус взрыва составляет 10 метров. Попавшие в зону поражения противники получают 250  взрывного урона. </p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%A8%D0%B8%D0%BF_%D1%8D%D0%BD%D1%82%D1%80%D0%BE%D0%BF%D0%B8%D0%B8",
+        "icon": "icons/ru/Entropy_Spike.000f2e27229f84cb2b9e1e8a5afcf1c7.png",
+        "thumb": "icons/ru/thumbs/Entropy_Spike.000f2e27229f84cb2b9e1e8a5afcf1c7.128x128.png",
+        "drop": [
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "엔트로피 스파이크",
+        "description": "<p>The Entropy Spike mod is a Weapon Augment Mod that adds an explosion chance and Entropy specifically for the Bolto. It increases the explosion chance by 0.05 and Entropy by 0.25 per rank, at a maximum of 0.2 and 1 at rank 3, respectively. Explosions deal 250  Blast damage to the target, as well as to nearby enemies within 10 meters of the blast (scaled by distance).</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Entropy_Spike",
+        "drop": [
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            }
+        ]
+    },
+    "rarity": "rare",
+    "mod_max_rank": 3,
+    "trading_tax": 8000
+}

--- a/queued_updates/items/Ergo's Boardroom Scene.json
+++ b/queued_updates/items/Ergo's Boardroom Scene.json
@@ -1,0 +1,45 @@
+{
+    "_id": "58e6407ada6e257f670cf06d",
+    "tags": [
+        "scene"
+    ],
+    "icon": "icons/en/Ergo's_Boardroom_Scene.1414f03ad87608a82dd1569804e2c2b3.png",
+    "thumb": "icons/en/thumbs/Ergo's_Boardroom_Scene.1414f03ad87608a82dd1569804e2c2b3.128x128.png",
+    "icon_format": "land",
+    "url_name": "ergos_boardroom_scene",
+    "tradable": true,
+    "en": {
+        "item_name": "Ergo's Boardroom Scene",
+        "description": "<p>Captura is an image capture and editing tool that allows players to manipulate and compose scenarios for screenshots.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Captura",
+        "drop": [
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Зал Эрго",
+        "description": "<p>Специальный режим, позволяющий делать красочные снимки.<br/>Для использования режима необходимо войти во Внешний вид и нажать Каптура.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%9A%D0%B0%D0%BF%D1%82%D1%83%D1%80%D0%B0",
+        "drop": [
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "에르고의 이사회실 배경",
+        "description": "<p>Captura is an image capture and editing tool that allows players to manipulate and compose scenarios for screenshots.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Captura",
+        "drop": [
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Eroding Blight.json
+++ b/queued_updates/items/Eroding Blight.json
@@ -1,0 +1,51 @@
+{
+    "_id": "54a74454e779892d5e5155a0",
+    "tags": [
+        "mod",
+        "weapons",
+        "rare"
+    ],
+    "icon": "icons/en/Eroding_Blight.8c40cf12f0b4d2b85870306b2ba2e5cd.png",
+    "thumb": "icons/en/thumbs/Eroding_Blight.8c40cf12f0b4d2b85870306b2ba2e5cd.128x128.png",
+    "icon_format": "port",
+    "url_name": "eroding_blight",
+    "tradable": true,
+    "en": {
+        "item_name": "Eroding Blight",
+        "description": "<p>The Eroding Blight mod is a Weapon Augment Mod that increases magazine capacity and Blight specifically for the Embolist. It increases magazine capacity by 50% and Blight by 0.25 per rank, at a maximum of 200% and 1 at rank 3, respectively.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Eroding_Blight",
+        "drop": [
+            {
+                "name": "Red Veil",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Энтропийная гниль",
+        "description": "<p>Энтропийная Гниль — мод-аугмент для оружия Эмболист, который увеличивает вместимость магазина и даёт прирост Синдикат-эффекта - Гниль.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%AD%D0%BD%D1%82%D1%80%D0%BE%D0%BF%D0%B8%D0%B9%D0%BD%D0%B0%D1%8F_%D0%B3%D0%BD%D0%B8%D0%BB%D1%8C",
+        "icon": "icons/ru/Eroding_Blight.b25d6f539c4dde34b15be327fc2c7bc0.png",
+        "thumb": "icons/ru/thumbs/Eroding_Blight.b25d6f539c4dde34b15be327fc2c7bc0.128x128.png",
+        "drop": [
+            {
+                "name": "Red Veil",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "엔로딩 블라이트",
+        "description": "<p>The Eroding Blight mod is a Weapon Augment Mod that increases magazine capacity and Blight specifically for the Embolist. It increases magazine capacity by 50% and Blight by 0.25 per rank, at a maximum of 200% and 1 at rank 3, respectively.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Eroding_Blight",
+        "drop": [
+            {
+                "name": "Red Veil",
+                "link": null
+            }
+        ]
+    },
+    "rarity": "rare",
+    "mod_max_rank": 3,
+    "trading_tax": 8000
+}

--- a/queued_updates/items/Fluctus Barrel.json
+++ b/queued_updates/items/Fluctus Barrel.json
@@ -1,0 +1,55 @@
+{
+    "_id": "5783bf15d9b6753790c89e8b",
+    "tags": [
+        "parts",
+        "archwing",
+        "barrel"
+    ],
+    "icon": "icons/en/Fluctus_Set.764b2148dde0c8969f748d6e0b80f957.png",
+    "thumb": "icons/en/thumbs/Fluctus_Set.764b2148dde0c8969f748d6e0b80f957.128x128.png",
+    "icon_format": "port",
+    "sub_icon": "sub_icons/barrel_128x128.png",
+    "url_name": "fluctus_barrel",
+    "tradable": true,
+    "part_of_set": [
+        "582b0f850af25410b099f7f9",
+        "5783bf15d9b6753790c89e8b",
+        "5783bf1ad9b6753790c89e8c",
+        "5783bf20d9b6753790c89e8d"
+    ],
+    "set_root": false,
+    "en": {
+        "item_name": "Fluctus Barrel",
+        "description": "<p>The Fluctus is an Archwing primary weapon which fires a wave of energy. It was released in Update 15.7.2.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Fluctus",
+        "drop": [
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Флактус Ствол",
+        "description": "<p>Энергетическое оружие Арчвинга, стреляющее сгустками плазмы, расщепляющей врагов.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%A4%D0%BB%D0%B0%D0%BA%D1%82%D1%83%D1%81",
+        "drop": [
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "플럭투스 배럴",
+        "description": "<p>The Fluctus is an Archwing primary weapon which fires a wave of energy. It was released in Update 15.7.2.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Fluctus",
+        "drop": [
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            }
+        ]
+    },
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Fluctus Limbs.json
+++ b/queued_updates/items/Fluctus Limbs.json
@@ -1,0 +1,54 @@
+{
+    "_id": "5783bf1ad9b6753790c89e8c",
+    "tags": [
+        "blueprint",
+        "archwing"
+    ],
+    "icon": "icons/en/Fluctus_Set.764b2148dde0c8969f748d6e0b80f957.png",
+    "thumb": "icons/en/thumbs/Fluctus_Set.764b2148dde0c8969f748d6e0b80f957.128x128.png",
+    "icon_format": "port",
+    "sub_icon": "sub_icons/generic_limbs_128x128.png",
+    "url_name": "fluctus_limbs",
+    "tradable": true,
+    "part_of_set": [
+        "582b0f850af25410b099f7f9",
+        "5783bf15d9b6753790c89e8b",
+        "5783bf1ad9b6753790c89e8c",
+        "5783bf20d9b6753790c89e8d"
+    ],
+    "set_root": false,
+    "en": {
+        "item_name": "Fluctus Limbs",
+        "description": "<p>The Fluctus is an Archwing primary weapon which fires a wave of energy. It was released in Update 15.7.2.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Fluctus",
+        "drop": [
+            {
+                "name": "Red Veil",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Флактус Плечи",
+        "description": "<p>Энергетическое оружие Арчвинга, стреляющее сгустками плазмы, расщепляющей врагов.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%A4%D0%BB%D0%B0%D0%BA%D1%82%D1%83%D1%81",
+        "drop": [
+            {
+                "name": "Red Veil",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "플럭투스 림",
+        "description": "<p>The Fluctus is an Archwing primary weapon which fires a wave of energy. It was released in Update 15.7.2.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Fluctus",
+        "drop": [
+            {
+                "name": "Red Veil",
+                "link": null
+            }
+        ]
+    },
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Fluctus Set.json
+++ b/queued_updates/items/Fluctus Set.json
@@ -1,0 +1,39 @@
+{
+    "_id": "582b0f850af25410b099f7f9",
+    "tags": [
+        "parts",
+        "archwing",
+        "set"
+    ],
+    "icon": "icons/en/Fluctus_Set.764b2148dde0c8969f748d6e0b80f957.png",
+    "thumb": "icons/en/thumbs/Fluctus_Set.764b2148dde0c8969f748d6e0b80f957.128x128.png",
+    "icon_format": "port",
+    "url_name": "fluctus_set",
+    "tradable": true,
+    "part_of_set": [
+        "582b0f850af25410b099f7f9",
+        "5783bf15d9b6753790c89e8b",
+        "5783bf1ad9b6753790c89e8c",
+        "5783bf20d9b6753790c89e8d"
+    ],
+    "set_root": true,
+    "en": {
+        "item_name": "Fluctus Set",
+        "description": "<p>The Fluctus is an Archwing primary weapon which fires a wave of energy. It was released in Update 15.7.2.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Fluctus",
+        "drop": []
+    },
+    "ru": {
+        "item_name": "Флактус Комплект",
+        "description": "<p>Энергетическое оружие Арчвинга, стреляющее сгустками плазмы, расщепляющей врагов.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%A4%D0%BB%D0%B0%D0%BA%D1%82%D1%83%D1%81",
+        "drop": []
+    },
+    "ko": {
+        "item_name": "플럭투스 세트",
+        "description": "<p>The Fluctus is an Archwing primary weapon which fires a wave of energy. It was released in Update 15.7.2.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Fluctus",
+        "drop": []
+    },
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Fluctus Stock.json
+++ b/queued_updates/items/Fluctus Stock.json
@@ -1,0 +1,55 @@
+{
+    "_id": "5783bf20d9b6753790c89e8d",
+    "tags": [
+        "parts",
+        "archwing",
+        "stock"
+    ],
+    "icon": "icons/en/Fluctus_Set.764b2148dde0c8969f748d6e0b80f957.png",
+    "thumb": "icons/en/thumbs/Fluctus_Set.764b2148dde0c8969f748d6e0b80f957.128x128.png",
+    "icon_format": "port",
+    "sub_icon": "sub_icons/stock_128x128.png",
+    "url_name": "fluctus_stock",
+    "tradable": true,
+    "part_of_set": [
+        "582b0f850af25410b099f7f9",
+        "5783bf15d9b6753790c89e8b",
+        "5783bf1ad9b6753790c89e8c",
+        "5783bf20d9b6753790c89e8d"
+    ],
+    "set_root": false,
+    "en": {
+        "item_name": "Fluctus Stock",
+        "description": "<p>The Fluctus is an Archwing primary weapon which fires a wave of energy. It was released in Update 15.7.2.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Fluctus",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Флактус Приклад",
+        "description": "<p>Энергетическое оружие Арчвинга, стреляющее сгустками плазмы, расщепляющей врагов.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%A4%D0%BB%D0%B0%D0%BA%D1%82%D1%83%D1%81",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "플럭투스 스톡",
+        "description": "<p>The Fluctus is an Archwing primary weapon which fires a wave of energy. It was released in Update 15.7.2.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Fluctus",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            }
+        ]
+    },
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Gilded Truth.json
+++ b/queued_updates/items/Gilded Truth.json
@@ -1,0 +1,51 @@
+{
+    "_id": "54a74454e779892d5e515664",
+    "tags": [
+        "mod",
+        "weapons",
+        "rare"
+    ],
+    "icon": "icons/en/Gilded_Truth.4f864f82b65bf77a28c01419c6cbfce1.png",
+    "thumb": "icons/en/thumbs/Gilded_Truth.4f864f82b65bf77a28c01419c6cbfce1.128x128.png",
+    "icon_format": "port",
+    "url_name": "gilded_truth",
+    "tradable": true,
+    "en": {
+        "item_name": "Gilded Truth",
+        "description": "<p>The Gilded Truth mod is a Weapon Augment Mod that increases Fire Rate and Truth specifically for the Burston Prime. It increases fire rate by 20% and Truth by 0.25 per rank, at a maximum of 80% and 1 at rank 3, respectively.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Gilded_Truth",
+        "drop": [
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Позолоченная правда",
+        "description": "<p>Позолоченная Правда — мод-аугмент для оружия Бёрстон Прайм, который увеличивает скорострельность и даёт прирост Синдикат-эффекта - Правда.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%9F%D0%BE%D0%B7%D0%BE%D0%BB%D0%BE%D1%87%D0%B5%D0%BD%D0%BD%D0%B0%D1%8F_%D0%BF%D1%80%D0%B0%D0%B2%D0%B4%D0%B0",
+        "icon": "icons/ru/Gilded_Truth.9531cf1d0010c53d4b709d5cb3263906.png",
+        "thumb": "icons/ru/thumbs/Gilded_Truth.9531cf1d0010c53d4b709d5cb3263906.128x128.png",
+        "drop": [
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "길디드 트루스",
+        "description": "<p>The Gilded Truth mod is a Weapon Augment Mod that increases Fire Rate and Truth specifically for the Burston Prime. It increases fire rate by 20% and Truth by 0.25 per rank, at a maximum of 80% and 1 at rank 3, respectively.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Gilded_Truth",
+        "drop": [
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            }
+        ]
+    },
+    "rarity": "rare",
+    "mod_max_rank": 3,
+    "trading_tax": 8000
+}

--- a/queued_updates/items/Gleaming Blight.json
+++ b/queued_updates/items/Gleaming Blight.json
@@ -1,0 +1,51 @@
+{
+    "_id": "54a74454e779892d5e5155d5",
+    "tags": [
+        "mod",
+        "weapons",
+        "rare"
+    ],
+    "icon": "icons/en/Gleaming_Blight.864cbc195d8dbbdb4adfdadd56d7de13.png",
+    "thumb": "icons/en/thumbs/Gleaming_Blight.864cbc195d8dbbdb4adfdadd56d7de13.128x128.png",
+    "icon_format": "port",
+    "url_name": "gleaming_blight",
+    "tradable": true,
+    "en": {
+        "item_name": "Gleaming Blight",
+        "description": "<p>The Gleaming Blight mod is a Weapon Augment Mod that increases status chance and Blight specifically for the Dark Dagger. It increases status chance by 25% and Blight by 0.25 per rank, at a maximum of 100% and 1 at rank 3, respectively.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Gleaming_Blight",
+        "drop": [
+            {
+                "name": "Red Veil",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Блестящая гниль",
+        "description": "<p>Блестящая Гниль — мод-аугмент для кинжалов: Темный Кинжал и Ракта тёмный кинжал, который увеличивает шанс срабатывания статуса на 25% за ранг. На максимальном ранге мода увеличения шанса срабатывания составляет 100%.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%91%D0%BB%D0%B5%D1%81%D1%82%D1%8F%D1%89%D0%B0%D1%8F_%D0%B3%D0%BD%D0%B8%D0%BB%D1%8C",
+        "icon": "icons/ru/Gleaming_Blight.80ec79901ed4bc8566ce8f9399968ea0.png",
+        "thumb": "icons/ru/thumbs/Gleaming_Blight.80ec79901ed4bc8566ce8f9399968ea0.128x128.png",
+        "drop": [
+            {
+                "name": "Red Veil",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "글리밍 블라이트",
+        "description": "<p>The Gleaming Blight mod is a Weapon Augment Mod that increases status chance and Blight specifically for the Dark Dagger. It increases status chance by 25% and Blight by 0.25 per rank, at a maximum of 100% and 1 at rank 3, respectively.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Gleaming_Blight",
+        "drop": [
+            {
+                "name": "Red Veil",
+                "link": null
+            }
+        ]
+    },
+    "rarity": "rare",
+    "mod_max_rank": 3,
+    "trading_tax": 8000
+}

--- a/queued_updates/items/Justice Blades.json
+++ b/queued_updates/items/Justice Blades.json
@@ -1,0 +1,51 @@
+{
+    "_id": "54a74455e779892d5e5156b9",
+    "tags": [
+        "weapons",
+        "mod",
+        "rare"
+    ],
+    "icon": "icons/en/Justice_Blades.465e02b8fa93e85a73dd5aa83e0808fb.png",
+    "thumb": "icons/en/thumbs/Justice_Blades.465e02b8fa93e85a73dd5aa83e0808fb.128x128.png",
+    "icon_format": "port",
+    "url_name": "justice_blades",
+    "tradable": true,
+    "en": {
+        "item_name": "Justice Blades",
+        "description": "<p>The Justice Blades mod is a Weapon Augment Mod that increases melee damage and Justice specifically for the Dual Cleavers. It increases melee damage by 25% and Justice by 0.25 per rank, at a maximum of 100% at ranks 1 and 3, respectively.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Justice_Blades",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Лезвия справедливости",
+        "description": "<p>Лезвия Справедливости — мод-аугмент для оружия Парные Секачи, который увеличивает урон и  даёт прирост Синдикат-эффекта - Справедливость.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%9B%D0%B5%D0%B7%D0%B2%D0%B8%D1%8F_%D1%81%D0%BF%D1%80%D0%B0%D0%B2%D0%B5%D0%B4%D0%BB%D0%B8%D0%B2%D0%BE%D1%81%D1%82%D0%B8",
+        "icon": "icons/ru/Justice_Blades.8a6c3482b8e0cd8c85c8a5097f3c9784.png",
+        "thumb": "icons/ru/thumbs/Justice_Blades.8a6c3482b8e0cd8c85c8a5097f3c9784.128x128.png",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "저스티스 블레이드",
+        "description": "<p>The Justice Blades mod is a Weapon Augment Mod that increases melee damage and Justice specifically for the Dual Cleavers. It increases melee damage by 25% and Justice by 0.25 per rank, at a maximum of 100% at ranks 1 and 3, respectively.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Justice_Blades",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            }
+        ]
+    },
+    "rarity": "rare",
+    "mod_max_rank": 3,
+    "trading_tax": 8000
+}

--- a/queued_updates/items/Kaszas Blade.json
+++ b/queued_updates/items/Kaszas Blade.json
@@ -1,0 +1,55 @@
+{
+    "_id": "5783bee2d9b6753790c89e87",
+    "tags": [
+        "parts",
+        "archwing",
+        "blade"
+    ],
+    "icon": "icons/en/Kaszas_Set.11baea8229af2d3500c79b829f9dfcee.png",
+    "thumb": "icons/en/thumbs/Kaszas_Set.11baea8229af2d3500c79b829f9dfcee.128x128.png",
+    "icon_format": "land",
+    "sub_icon": "sub_icons/blade_128x128.png",
+    "url_name": "kaszas_blade",
+    "tradable": true,
+    "part_of_set": [
+        "582b0f630af25410b099f7f7",
+        "5783bee2d9b6753790c89e87",
+        "5783bea1d9b6753790c89e86"
+    ],
+    "set_root": false,
+    "en": {
+        "item_name": "Kaszas Blade",
+        "description": "<p>The Kaszas is an Archwing scythe released in Update 17.5.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Kaszas",
+        "drop": [
+            {
+                "name": "Red Veil",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Косаш Клинок",
+        "description": "<p>Станьте ангелом смерти с этой косой для Арчвингов</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%9A%D0%BE%D1%81%D0%B0%D1%88",
+        "drop": [
+            {
+                "name": "Red Veil",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "카스자스 블레이드",
+        "description": "<p>The Kaszas is an Archwing scythe released in Update 17.5.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Kaszas",
+        "drop": [
+            {
+                "name": "Red Veil",
+                "link": null
+            }
+        ]
+    },
+    "mastery_level": 0,
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Kaszas Handle.json
+++ b/queued_updates/items/Kaszas Handle.json
@@ -1,0 +1,55 @@
+{
+    "_id": "5783bea1d9b6753790c89e86",
+    "tags": [
+        "parts",
+        "archwing",
+        "handle"
+    ],
+    "icon": "icons/en/Kaszas_Set.11baea8229af2d3500c79b829f9dfcee.png",
+    "thumb": "icons/en/thumbs/Kaszas_Set.11baea8229af2d3500c79b829f9dfcee.128x128.png",
+    "icon_format": "land",
+    "sub_icon": "sub_icons/handle_128x128.png",
+    "url_name": "kaszas_handle",
+    "tradable": true,
+    "part_of_set": [
+        "582b0f630af25410b099f7f7",
+        "5783bee2d9b6753790c89e87",
+        "5783bea1d9b6753790c89e86"
+    ],
+    "set_root": false,
+    "en": {
+        "item_name": "Kaszas Handle",
+        "description": "<p>The Kaszas is an Archwing scythe released in Update 17.5.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Kaszas",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Косаш Рукоять",
+        "description": "<p>Станьте ангелом смерти с этой косой для Арчвингов</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%9A%D0%BE%D1%81%D0%B0%D1%88",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "카스자스 핸들",
+        "description": "<p>The Kaszas is an Archwing scythe released in Update 17.5.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Kaszas",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            }
+        ]
+    },
+    "mastery_level": 0,
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Kaszas Set.json
+++ b/queued_updates/items/Kaszas Set.json
@@ -1,0 +1,39 @@
+{
+    "_id": "582b0f630af25410b099f7f7",
+    "tags": [
+        "parts",
+        "archwing",
+        "set"
+    ],
+    "icon": "icons/en/Kaszas_Set.11baea8229af2d3500c79b829f9dfcee.png",
+    "thumb": "icons/en/thumbs/Kaszas_Set.11baea8229af2d3500c79b829f9dfcee.128x128.png",
+    "icon_format": "land",
+    "url_name": "kaszas_set",
+    "tradable": true,
+    "part_of_set": [
+        "582b0f630af25410b099f7f7",
+        "5783bee2d9b6753790c89e87",
+        "5783bea1d9b6753790c89e86"
+    ],
+    "set_root": true,
+    "en": {
+        "item_name": "Kaszas Set",
+        "description": "<p>The Kaszas is an Archwing scythe released in Update 17.5.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Kaszas",
+        "drop": []
+    },
+    "ru": {
+        "item_name": "Косаш Комплект",
+        "description": "<p>Станьте ангелом смерти с этой косой для Арчвингов</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%9A%D0%BE%D1%81%D0%B0%D1%88",
+        "drop": []
+    },
+    "ko": {
+        "item_name": "카스자스 세트",
+        "description": "<p>The Kaszas is an Archwing scythe released in Update 17.5.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Kaszas",
+        "drop": []
+    },
+    "mastery_level": 0,
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Larva Burst.json
+++ b/queued_updates/items/Larva Burst.json
@@ -1,0 +1,61 @@
+{
+    "_id": "5a6b495c7f2bca025fde2b58",
+    "tags": [
+        "mod",
+        "nidus",
+        "rare"
+    ],
+    "icon": "icons/en/Larva_Burst.cc35be884ce7c5ef3c9913a9586a76aa.png",
+    "thumb": "icons/en/thumbs/Larva_Burst.cc35be884ce7c5ef3c9913a9586a76aa.128x128.png",
+    "icon_format": "port",
+    "url_name": "larva_burst",
+    "tradable": true,
+    "en": {
+        "item_name": "Larva Burst",
+        "description": "<p>Larva Burst is a Warframe Augment Mod for Nidus's Larva that allows the player to detonate Larva for Toxin b Toxin damage in a small AoE by reactivating the ability. This damage stacks for every enemy grabbed by the Larva.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Larva_Burst",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            },
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Larva Burst",
+        "description": "<p>Larva Burst is a Warframe Augment Mod for Nidus's Larva that allows the player to detonate Larva for Toxin b Toxin damage in a small AoE by reactivating the ability. This damage stacks for every enemy grabbed by the Larva.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Larva_Burst",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            },
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "라바 버스트",
+        "description": "<p>Larva Burst is a Warframe Augment Mod for Nidus's Larva that allows the player to detonate Larva for Toxin b Toxin damage in a small AoE by reactivating the ability. This damage stacks for every enemy grabbed by the Larva.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Larva_Burst",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            },
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "rarity": "rare",
+    "mod_max_rank": 3,
+    "trading_tax": 8000
+}

--- a/queued_updates/items/Lasting Purity.json
+++ b/queued_updates/items/Lasting Purity.json
@@ -1,0 +1,51 @@
+{
+    "_id": "54a74454e779892d5e5155b8",
+    "tags": [
+        "mod",
+        "weapons",
+        "rare"
+    ],
+    "icon": "icons/en/Lasting_Purity.702ff6d12dcff064a4b9d24ba344260c.png",
+    "thumb": "icons/en/thumbs/Lasting_Purity.702ff6d12dcff064a4b9d24ba344260c.128x128.png",
+    "icon_format": "port",
+    "url_name": "lasting_purity",
+    "tradable": true,
+    "en": {
+        "item_name": "Lasting Purity",
+        "description": "<p>The Lasting Purity mod is a Weapon Augment Mod that adds Dead Aim (damage while zoomed in) and Purity specifically for the Vulkar and Vulkar Wraith. It increases Dead Aim by 15% and Purity by 0.25 per rank, at a maximum of 60% and 1 at rank 3, respectively. </p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Lasting_Purity",
+        "drop": [
+            {
+                "name": "New Loka",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Убеждённая чистота",
+        "description": "<p>Убежденная Чистота — мод-аугмент для оружия Вулкар, который  увеличивает урон при прицеливании и даёт прирост синдикат-эффетка - Чистота.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%A3%D0%B1%D0%B5%D0%B6%D0%B4%D1%91%D0%BD%D0%BD%D0%B0%D1%8F_%D1%87%D0%B8%D1%81%D1%82%D0%BE%D1%82%D0%B0",
+        "icon": "icons/ru/Lasting_Purity.d40c649b4fe0d3b4f78b58469d5b3164.png",
+        "thumb": "icons/ru/thumbs/Lasting_Purity.d40c649b4fe0d3b4f78b58469d5b3164.128x128.png",
+        "drop": [
+            {
+                "name": "New Loka",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "라스팅 퓨리티",
+        "description": "<p>The Lasting Purity mod is a Weapon Augment Mod that adds Dead Aim (damage while zoomed in) and Purity specifically for the Vulkar and Vulkar Wraith. It increases Dead Aim by 15% and Purity by 0.25 per rank, at a maximum of 60% and 1 at rank 3, respectively. </p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Lasting_Purity",
+        "drop": [
+            {
+                "name": "New Loka",
+                "link": null
+            }
+        ]
+    },
+    "rarity": "rare",
+    "mod_max_rank": 3,
+    "trading_tax": 8000
+}

--- a/queued_updates/items/Mesa’s Waltz.json
+++ b/queued_updates/items/Mesa’s Waltz.json
@@ -1,0 +1,74 @@
+{
+    "_id": "56dac56a5cc639de0a45c51b",
+    "tags": [
+        "mod",
+        "rare",
+        "pve",
+        "pvp"
+    ],
+    "icon": "icons/en/Mesa’s_Waltz.d6c93034e5a61cb41cf18a64466e3eec.png",
+    "thumb": "icons/en/thumbs/Mesa’s_Waltz.d6c93034e5a61cb41cf18a64466e3eec.128x128.png",
+    "icon_format": "port",
+    "url_name": "mesa’s_waltz",
+    "tradable": true,
+    "en": {
+        "item_name": "Mesa’s Waltz",
+        "description": "<p>Mesa's Waltz is a Warframe Augment Mod usable in both PvE and PvP that allows Mesa to move at half speed while channeling Peacemaker.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Mesa%27s_Waltz",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            },
+            {
+                "name": "Red Veil",
+                "link": null
+            },
+            {
+                "name": "Conclave Offering",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Вальс Мисы",
+        "description": "<p>Вальс Мисы — мод-аугмент для способности Мисы Миротворец, который позволяет ей передвигаться при использовании данной способности, со скоростью равной 50% от ее скорости передвижения.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%92%D0%B0%D0%BB%D1%8C%D1%81_%D0%9C%D0%B8%D1%81%D1%8B",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            },
+            {
+                "name": "Red Veil",
+                "link": null
+            },
+            {
+                "name": "Conclave Offering",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "메사 왈츠",
+        "description": "<p>Mesa's Waltz is a Warframe Augment Mod usable in both PvE and PvP that allows Mesa to move at half speed while channeling Peacemaker.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Mesa%27s_Waltz",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            },
+            {
+                "name": "Red Veil",
+                "link": null
+            },
+            {
+                "name": "Conclave Offering",
+                "link": null
+            }
+        ]
+    },
+    "rarity": "rare",
+    "mod_max_rank": 3,
+    "trading_tax": 8000
+}

--- a/queued_updates/items/Neutralizing Justice.json
+++ b/queued_updates/items/Neutralizing Justice.json
@@ -1,0 +1,62 @@
+{
+    "_id": "5911f11d97a0add8e9d5da4d",
+    "tags": [
+        "mod",
+        "miter"
+    ],
+    "icon": "icons/en/Neutralizing_Justice.07728fc8496c758312e086bb788ad1ea.png",
+    "thumb": "icons/en/thumbs/Neutralizing_Justice.07728fc8496c758312e086bb788ad1ea.128x128.png",
+    "icon_format": "port",
+    "url_name": "neutralizing_justice",
+    "tradable": true,
+    "en": {
+        "item_name": "Neutralizing Justice",
+        "description": "<p>Neutralizing Justice gives each Miter blade a chance to instantly destroy a Nullifier's bubble. It also adds a Justice effect.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Neutralizing_Justice",
+        "drop": [
+            {
+                "name": "Operation: Ambulas Reborn",
+                "link": null
+            },
+            {
+                "name": "Steel Meridian",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Нейтрализующая Справедливость",
+        "description": "<p>Нейтрализующая Справедливость — Мод-Аугмент для оружия Митра, дающий шанс каждому лезвию мгновенно уничтожить поле Нуллификатора, а так же прирост синдикат-эффекта — Справедливость.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%9D%D0%B5%D0%B9%D1%82%D1%80%D0%B0%D0%BB%D0%B8%D0%B7%D1%83%D1%8E%D1%89%D0%B0%D1%8F_%D0%A1%D0%BF%D1%80%D0%B0%D0%B2%D0%B5%D0%B4%D0%BB%D0%B8%D0%B2%D0%BE%D1%81%D1%82%D1%8C",
+        "icon": "icons/ru/Neutralizing_Justice.1b7259e61014c0dff8ed5185dc967c79.png",
+        "thumb": "icons/ru/thumbs/Neutralizing_Justice.1b7259e61014c0dff8ed5185dc967c79.128x128.png",
+        "drop": [
+            {
+                "name": "Operation: Ambulas Reborn",
+                "link": null
+            },
+            {
+                "name": "Steel Meridian",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "뉴트럴라이징 저스티스",
+        "description": "<p>Neutralizing Justice gives each Miter blade a chance to instantly destroy a Nullifier's bubble. It also adds a Justice effect.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Neutralizing_Justice",
+        "drop": [
+            {
+                "name": "Operation: Ambulas Reborn",
+                "link": null
+            },
+            {
+                "name": "Steel Meridian",
+                "link": null
+            }
+        ]
+    },
+    "rarity": "rare",
+    "mod_max_rank": 3,
+    "trading_tax": 8000
+}

--- a/queued_updates/items/Onorix Blade.json
+++ b/queued_updates/items/Onorix Blade.json
@@ -1,0 +1,54 @@
+{
+    "_id": "5783bf54d9b6753790c89e97",
+    "tags": [
+        "parts",
+        "archwing",
+        "blade"
+    ],
+    "icon": "icons/en/Onorix_Set.04c7efcf7c6239c88c275d164d6a259a.png",
+    "thumb": "icons/en/thumbs/Onorix_Set.04c7efcf7c6239c88c275d164d6a259a.128x128.png",
+    "icon_format": "land",
+    "sub_icon": "sub_icons/blade_128x128.png",
+    "url_name": "onorix_blade",
+    "tradable": true,
+    "part_of_set": [
+        "582b0f880af25410b099f7fd",
+        "5783bf54d9b6753790c89e97",
+        "5783bf4ed9b6753790c89e96"
+    ],
+    "set_root": false,
+    "en": {
+        "item_name": "Onorix Blade",
+        "description": "<p>The Onorix is a heavy axe designed for use with the Archwing flight system.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Onorix",
+        "drop": [
+            {
+                "name": "New Loka",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Онорикс Клинок",
+        "description": "<p>Эта секира с лазерной кромкой лезвий легко пронзает защиту корабля и сил, его обороняющих</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%9E%D0%BD%D0%BE%D1%80%D0%B8%D0%BA%D1%81",
+        "drop": [
+            {
+                "name": "New Loka",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "오노릭스 블레이드",
+        "description": "<p>The Onorix is a heavy axe designed for use with the Archwing flight system.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Onorix",
+        "drop": [
+            {
+                "name": "New Loka",
+                "link": null
+            }
+        ]
+    },
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Onorix Handle.json
+++ b/queued_updates/items/Onorix Handle.json
@@ -1,0 +1,54 @@
+{
+    "_id": "5783bf4ed9b6753790c89e96",
+    "tags": [
+        "parts",
+        "archwing",
+        "handle"
+    ],
+    "icon": "icons/en/Onorix_Set.04c7efcf7c6239c88c275d164d6a259a.png",
+    "thumb": "icons/en/thumbs/Onorix_Set.04c7efcf7c6239c88c275d164d6a259a.128x128.png",
+    "icon_format": "land",
+    "sub_icon": "sub_icons/handle_128x128.png",
+    "url_name": "onorix_handle",
+    "tradable": true,
+    "part_of_set": [
+        "582b0f880af25410b099f7fd",
+        "5783bf54d9b6753790c89e97",
+        "5783bf4ed9b6753790c89e96"
+    ],
+    "set_root": false,
+    "en": {
+        "item_name": "Onorix Handle",
+        "description": "<p>The Onorix is a heavy axe designed for use with the Archwing flight system.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Onorix",
+        "drop": [
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Онорикс Рукоять",
+        "description": "<p>Эта секира с лазерной кромкой лезвий легко пронзает защиту корабля и сил, его обороняющих</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%9E%D0%BD%D0%BE%D1%80%D0%B8%D0%BA%D1%81",
+        "drop": [
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "오노릭스 핸들",
+        "description": "<p>The Onorix is a heavy axe designed for use with the Archwing flight system.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Onorix",
+        "drop": [
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Onorix Set.json
+++ b/queued_updates/items/Onorix Set.json
@@ -1,0 +1,38 @@
+{
+    "_id": "582b0f880af25410b099f7fd",
+    "tags": [
+        "parts",
+        "archwing",
+        "set"
+    ],
+    "icon": "icons/en/Onorix_Set.04c7efcf7c6239c88c275d164d6a259a.png",
+    "thumb": "icons/en/thumbs/Onorix_Set.04c7efcf7c6239c88c275d164d6a259a.128x128.png",
+    "icon_format": "land",
+    "url_name": "onorix_set",
+    "tradable": true,
+    "part_of_set": [
+        "582b0f880af25410b099f7fd",
+        "5783bf54d9b6753790c89e97",
+        "5783bf4ed9b6753790c89e96"
+    ],
+    "set_root": true,
+    "en": {
+        "item_name": "Onorix Set",
+        "description": "<p>The Onorix is a heavy axe designed for use with the Archwing flight system.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Onorix",
+        "drop": []
+    },
+    "ru": {
+        "item_name": "Онорикс Комплект",
+        "description": "<p>Эта секира с лазерной кромкой лезвий легко пронзает защиту корабля и сил, его обороняющих</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%9E%D0%BD%D0%BE%D1%80%D0%B8%D0%BA%D1%81",
+        "drop": []
+    },
+    "ko": {
+        "item_name": "오노릭스 세트",
+        "description": "<p>The Onorix is a heavy axe designed for use with the Archwing flight system.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Onorix",
+        "drop": []
+    },
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Phaedra Barrel.json
+++ b/queued_updates/items/Phaedra Barrel.json
@@ -1,0 +1,55 @@
+{
+    "_id": "5783bf32d9b6753790c89e90",
+    "tags": [
+        "parts",
+        "archwing",
+        "barrel"
+    ],
+    "icon": "icons/en/Phaedra_Set.93a06c74d5ecc242c76ea0ff91e3d9ca.png",
+    "thumb": "icons/en/thumbs/Phaedra_Set.93a06c74d5ecc242c76ea0ff91e3d9ca.128x128.png",
+    "icon_format": "land",
+    "sub_icon": "sub_icons/barrel_128x128.png",
+    "url_name": "phaedra_barrel",
+    "tradable": true,
+    "part_of_set": [
+        "582b0f870af25410b099f7fb",
+        "5783bf32d9b6753790c89e90",
+        "5783bf37d9b6753790c89e91",
+        "5783bf3cd9b6753790c89e92"
+    ],
+    "set_root": false,
+    "en": {
+        "item_name": "Phaedra Barrel",
+        "description": "<p>The Phaedra is a large-caliber Archwing rifle that shares design aesthetics and mechanics to the Soma. It was released in Update 17.5.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Phaedra",
+        "drop": [
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Федра Ствол",
+        "description": "<p>Уничтожайте врагов в космосе при помощи Федры, старшей сестры Сомы.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%A4%D0%B5%D0%B4%D1%80%D0%B0",
+        "drop": [
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "파이드라 배럴",
+        "description": "<p>The Phaedra is a large-caliber Archwing rifle that shares design aesthetics and mechanics to the Soma. It was released in Update 17.5.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Phaedra",
+        "drop": [
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            }
+        ]
+    },
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Phaedra Receiver.json
+++ b/queued_updates/items/Phaedra Receiver.json
@@ -1,0 +1,67 @@
+{
+    "_id": "5783bf37d9b6753790c89e91",
+    "tags": [
+        "parts",
+        "archwing",
+        "receiver"
+    ],
+    "icon": "icons/en/Phaedra_Set.93a06c74d5ecc242c76ea0ff91e3d9ca.png",
+    "thumb": "icons/en/thumbs/Phaedra_Set.93a06c74d5ecc242c76ea0ff91e3d9ca.128x128.png",
+    "icon_format": "land",
+    "sub_icon": "sub_icons/receiver_128x128.png",
+    "url_name": "phaedra_receiver",
+    "tradable": true,
+    "part_of_set": [
+        "582b0f870af25410b099f7fb",
+        "5783bf32d9b6753790c89e90",
+        "5783bf37d9b6753790c89e91",
+        "5783bf3cd9b6753790c89e92"
+    ],
+    "set_root": false,
+    "en": {
+        "item_name": "Phaedra Receiver",
+        "description": "<p>The Phaedra is a large-caliber Archwing rifle that shares design aesthetics and mechanics to the Soma. It was released in Update 17.5.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Phaedra",
+        "drop": [
+            {
+                "name": "Archwing Exterminate",
+                "link": null
+            },
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Федра Приемник",
+        "description": "<p>Уничтожайте врагов в космосе при помощи Федры, старшей сестры Сомы.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%A4%D0%B5%D0%B4%D1%80%D0%B0",
+        "drop": [
+            {
+                "name": "Archwing Exterminate",
+                "link": null
+            },
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "파이드라 리시버",
+        "description": "<p>The Phaedra is a large-caliber Archwing rifle that shares design aesthetics and mechanics to the Soma. It was released in Update 17.5.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Phaedra",
+        "drop": [
+            {
+                "name": "Archwing Exterminate",
+                "link": null
+            },
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Phaedra Set.json
+++ b/queued_updates/items/Phaedra Set.json
@@ -1,0 +1,39 @@
+{
+    "_id": "582b0f870af25410b099f7fb",
+    "tags": [
+        "parts",
+        "archwing",
+        "set"
+    ],
+    "icon": "icons/en/Phaedra_Set.93a06c74d5ecc242c76ea0ff91e3d9ca.png",
+    "thumb": "icons/en/thumbs/Phaedra_Set.93a06c74d5ecc242c76ea0ff91e3d9ca.128x128.png",
+    "icon_format": "land",
+    "url_name": "phaedra_set",
+    "tradable": true,
+    "part_of_set": [
+        "582b0f870af25410b099f7fb",
+        "5783bf32d9b6753790c89e90",
+        "5783bf37d9b6753790c89e91",
+        "5783bf3cd9b6753790c89e92"
+    ],
+    "set_root": true,
+    "en": {
+        "item_name": "Phaedra Set",
+        "description": "<p>The Phaedra is a large-caliber Archwing rifle that shares design aesthetics and mechanics to the Soma. It was released in Update 17.5.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Phaedra",
+        "drop": []
+    },
+    "ru": {
+        "item_name": "Федра Комплект",
+        "description": "<p>Уничтожайте врагов в космосе при помощи Федры, старшей сестры Сомы.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%A4%D0%B5%D0%B4%D1%80%D0%B0",
+        "drop": []
+    },
+    "ko": {
+        "item_name": "파이드라 세트",
+        "description": "<p>The Phaedra is a large-caliber Archwing rifle that shares design aesthetics and mechanics to the Soma. It was released in Update 17.5.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Phaedra",
+        "drop": []
+    },
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Phaedra Stock.json
+++ b/queued_updates/items/Phaedra Stock.json
@@ -1,0 +1,55 @@
+{
+    "_id": "5783bf3cd9b6753790c89e92",
+    "tags": [
+        "parts",
+        "archwing",
+        "stock"
+    ],
+    "icon": "icons/en/Phaedra_Set.93a06c74d5ecc242c76ea0ff91e3d9ca.png",
+    "thumb": "icons/en/thumbs/Phaedra_Set.93a06c74d5ecc242c76ea0ff91e3d9ca.128x128.png",
+    "icon_format": "land",
+    "sub_icon": "sub_icons/stock_128x128.png",
+    "url_name": "phaedra_stock",
+    "tradable": true,
+    "part_of_set": [
+        "582b0f870af25410b099f7fb",
+        "5783bf32d9b6753790c89e90",
+        "5783bf37d9b6753790c89e91",
+        "5783bf3cd9b6753790c89e92"
+    ],
+    "set_root": false,
+    "en": {
+        "item_name": "Phaedra Stock",
+        "description": "<p>The Phaedra is a large-caliber Archwing rifle that shares design aesthetics and mechanics to the Soma. It was released in Update 17.5.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Phaedra",
+        "drop": [
+            {
+                "name": "New Loka",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Федра Приклад",
+        "description": "<p>Уничтожайте врагов в космосе при помощи Федры, старшей сестры Сомы.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%A4%D0%B5%D0%B4%D1%80%D0%B0",
+        "drop": [
+            {
+                "name": "New Loka",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "파이드라 스톡",
+        "description": "<p>The Phaedra is a large-caliber Archwing rifle that shares design aesthetics and mechanics to the Soma. It was released in Update 17.5.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Phaedra",
+        "drop": [
+            {
+                "name": "New Loka",
+                "link": null
+            }
+        ]
+    },
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Radiant Finish.json
+++ b/queued_updates/items/Radiant Finish.json
@@ -1,0 +1,63 @@
+{
+    "_id": "554d3af4e77989420d3de2a6",
+    "tags": [
+        "mod",
+        "pve",
+        "rare"
+    ],
+    "icon": "icons/en/Radiant_Finish.e4571603960bba734886efc1e0a0968b.png",
+    "thumb": "icons/en/thumbs/Radiant_Finish.e4571603960bba734886efc1e0a0968b.128x128.png",
+    "icon_format": "port",
+    "url_name": "radiant_finish",
+    "tradable": true,
+    "en": {
+        "item_name": "Radiant Finish",
+        "description": "<p>Radiant Finish is a Warframe Augment Mod for Excalibur that increases the damage dealt by finishers against enemies affected by Radial Blind.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Radiant_Finish",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            },
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Блестящее завершение",
+        "description": "<p>Блестящее Завершение — мод-аугмент для варфрейма Экскалибур и Экскалибур Прайм, улучшающий его способность Ослепляющий Свет. Врагам, подверженным эффекту умения, можно нанести завершающий удар с увеличенным уроном.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%91%D0%BB%D0%B5%D1%81%D1%82%D1%8F%D1%89%D0%B5%D0%B5_%D0%B7%D0%B0%D0%B2%D0%B5%D1%80%D1%88%D0%B5%D0%BD%D0%B8%D0%B5",
+        "icon": "icons/ru/Radiant_Finish.679a18cfd9fa20649f4fed116e690983.png",
+        "thumb": "icons/ru/thumbs/Radiant_Finish.679a18cfd9fa20649f4fed116e690983.128x128.png",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            },
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "레이디언트 피니쉬",
+        "description": "<p>Radiant Finish is a Warframe Augment Mod for Excalibur that increases the damage dealt by finishers against enemies affected by Radial Blind.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Radiant_Finish",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            },
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            }
+        ]
+    },
+    "rarity": "rare",
+    "mod_max_rank": 3,
+    "trading_tax": 8000
+}

--- a/queued_updates/items/Rakta Ballistica.json
+++ b/queued_updates/items/Rakta Ballistica.json
@@ -1,0 +1,47 @@
+{
+    "_id": "54aae2a0e7798911533cb007",
+    "tags": [
+        "syndicate",
+        "special weapons"
+    ],
+    "icon": "icons/en/Rakta_Ballistica.2e338918b2298e17fa465e83d319cc13.png",
+    "thumb": "icons/en/thumbs/Rakta_Ballistica.2e338918b2298e17fa465e83d319cc13.128x128.png",
+    "icon_format": "port",
+    "url_name": "rakta_ballistica",
+    "tradable": true,
+    "en": {
+        "item_name": "Rakta Ballistica",
+        "description": "<p>The Rakta Ballistica is an exclusive version of the Ballistica available only from the Red Veil. The Rakta Ballistica has a higher portion of  Puncture damage than its default version, and features a larger magazine as well as innate Blight effect.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Rakta_Ballistica",
+        "drop": [
+            {
+                "name": "Red Veil",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Ракта баллистика",
+        "description": "<p>Эта модифицированная Баллистика - выбор Красных Вуалей, когда им требуется устранить цель с высоким приоритетом.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%A0%D0%B0%D0%BA%D1%82%D0%B0_%D0%B1%D0%B0%D0%BB%D0%BB%D0%B8%D1%81%D1%82%D0%B8%D0%BA%D0%B0",
+        "drop": [
+            {
+                "name": "Red Veil",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "락타 발리스티카",
+        "description": "<p>The Rakta Ballistica is an exclusive version of the Ballistica available only from the Red Veil. The Rakta Ballistica has a higher portion of  Puncture damage than its default version, and features a larger magazine as well as innate Blight effect.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Rakta_Ballistica",
+        "drop": [
+            {
+                "name": "Red Veil",
+                "link": null
+            }
+        ]
+    },
+    "mastery_level": 6,
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Rakta Cernos.json
+++ b/queued_updates/items/Rakta Cernos.json
@@ -1,0 +1,48 @@
+{
+    "_id": "55e797f3e77989249d164946",
+    "tags": [
+        "syndicate",
+        "weapon",
+        "special weapons"
+    ],
+    "icon": "icons/en/Rakta_Cernos.3ca06a77423c5b28b8d7a9f9d860a92c.png",
+    "thumb": "icons/en/thumbs/Rakta_Cernos.3ca06a77423c5b28b8d7a9f9d860a92c.128x128.png",
+    "icon_format": "land",
+    "url_name": "rakta_cernos",
+    "tradable": true,
+    "en": {
+        "item_name": "Rakta Cernos",
+        "description": "<p>The Rakta Cernos is a modified Cernos bow exclusively available to the Red Veil. It features the fastest charge time of all bows, along with increased base damage, status chance, and innate Blight effect. </p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Rakta_Cernos",
+        "drop": [
+            {
+                "name": "Red Veil",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Ракта кернунн",
+        "description": "<p>Искуссный инструмент умерщвления</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%A0%D0%B0%D0%BA%D1%82%D0%B0_%D0%BA%D0%B5%D1%80%D0%BD%D1%83%D0%BD%D0%BD",
+        "drop": [
+            {
+                "name": "Red Veil",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "락타 세르노스",
+        "description": "<p>The Rakta Cernos is a modified Cernos bow exclusively available to the Red Veil. It features the fastest charge time of all bows, along with increased base damage, status chance, and innate Blight effect. </p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Rakta_Cernos",
+        "drop": [
+            {
+                "name": "Red Veil",
+                "link": null
+            }
+        ]
+    },
+    "mastery_level": 12,
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Rakta Dark Dagger.json
+++ b/queued_updates/items/Rakta Dark Dagger.json
@@ -1,0 +1,47 @@
+{
+    "_id": "57dbdc525e334907aa8edb59",
+    "tags": [
+        "syndicate",
+        "melee"
+    ],
+    "icon": "icons/en/Rakta_Dark_Dagger.c59954c3d3a9a925e98caee4ac7d20af.png",
+    "thumb": "icons/en/thumbs/Rakta_Dark_Dagger.c59954c3d3a9a925e98caee4ac7d20af.128x128.png",
+    "icon_format": "land",
+    "url_name": "rakta_dark_dagger",
+    "tradable": true,
+    "en": {
+        "item_name": "Rakta Dark Dagger",
+        "description": "<p>The Rakta Dark Dagger is the Syndicate variant of the Dark Dagger, available from the Red Veil. While held, It reduces visibility  and restores shields or grants overshields when damaging a target afflicted by  Radiation.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Rakta_Dark_Dagger",
+        "drop": [
+            {
+                "name": "Red Veil",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Ракта Тёмный кинжал",
+        "description": "<p>Проникайте скрытно: дарует пониженную заметность, когда находится в руках. После - наносите уверенные удары; атаки по облучённым целям восстанавливают щиты и создают сверхщиты.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%A0%D0%B0%D0%BA%D1%82%D0%B0_%D1%82%D1%91%D0%BC%D0%BD%D1%8B%D0%B9_%D0%BA%D0%B8%D0%BD%D0%B6%D0%B0%D0%BB",
+        "drop": [
+            {
+                "name": "Red Veil",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "락타 다크 대거",
+        "description": "<p>The Rakta Dark Dagger is the Syndicate variant of the Dark Dagger, available from the Red Veil. While held, It reduces visibility  and restores shields or grants overshields when damaging a target afflicted by  Radiation.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Rakta_Dark_Dagger",
+        "drop": [
+            {
+                "name": "Red Veil",
+                "link": null
+            }
+        ]
+    },
+    "mastery_level": 8,
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Rathbone Handle.json
+++ b/queued_updates/items/Rathbone Handle.json
@@ -1,0 +1,54 @@
+{
+    "_id": "578d33bf34003bbbb9e20924",
+    "tags": [
+        "parts",
+        "archwing",
+        "handle"
+    ],
+    "icon": "icons/en/Rathbone_Set.7e6a0db9a09fae95a9f6a4e96b1f0979.png",
+    "thumb": "icons/en/thumbs/Rathbone_Set.7e6a0db9a09fae95a9f6a4e96b1f0979.128x128.png",
+    "icon_format": "land",
+    "sub_icon": "sub_icons/handle_128x128.png",
+    "url_name": "rathbone_handle",
+    "tradable": true,
+    "part_of_set": [
+        "582b0f8a0af25410b099f800",
+        "578d33bf34003bbbb9e20924",
+        "578d33bf34003bbbb9e20925"
+    ],
+    "set_root": false,
+    "en": {
+        "item_name": "Rathbone Handle",
+        "description": "<p>A heavy Hammer exclusive to Archwing use, the Rathbone primarily deals  Impact damage, which is ideal for taking down Corpus shields. This weapon shares its own basic six combo with Centaur.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Rathbone",
+        "drop": [
+            {
+                "name": "Red Veil",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Рэтбон Рукоять",
+        "description": "<p>Используя реактивную силу Арчвинга, этот массивный молот разрушает всё на своём пути</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%A0%D1%8D%D1%82%D0%B1%D0%BE%D0%BD",
+        "drop": [
+            {
+                "name": "Red Veil",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "래스본 핸들",
+        "description": "<p>A heavy Hammer exclusive to Archwing use, the Rathbone primarily deals  Impact damage, which is ideal for taking down Corpus shields. This weapon shares its own basic six combo with Centaur.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Rathbone",
+        "drop": [
+            {
+                "name": "Red Veil",
+                "link": null
+            }
+        ]
+    },
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Rathbone Head.json
+++ b/queued_updates/items/Rathbone Head.json
@@ -1,0 +1,53 @@
+{
+    "_id": "578d33bf34003bbbb9e20925",
+    "tags": [
+        "blueprint",
+        "archwing"
+    ],
+    "icon": "icons/en/Rathbone_Set.7e6a0db9a09fae95a9f6a4e96b1f0979.png",
+    "thumb": "icons/en/thumbs/Rathbone_Set.7e6a0db9a09fae95a9f6a4e96b1f0979.128x128.png",
+    "icon_format": "land",
+    "sub_icon": "sub_icons/generic_head_128x128.png",
+    "url_name": "rathbone_head",
+    "tradable": true,
+    "part_of_set": [
+        "582b0f8a0af25410b099f800",
+        "578d33bf34003bbbb9e20924",
+        "578d33bf34003bbbb9e20925"
+    ],
+    "set_root": false,
+    "en": {
+        "item_name": "Rathbone Head",
+        "description": "<p>A heavy Hammer exclusive to Archwing use, the Rathbone primarily deals  Impact damage, which is ideal for taking down Corpus shields. This weapon shares its own basic six combo with Centaur.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Rathbone",
+        "drop": [
+            {
+                "name": "New Loka",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Рэтбон",
+        "description": "<p>Используя реактивную силу Арчвинга, этот массивный молот разрушает всё на своём пути</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%A0%D1%8D%D1%82%D0%B1%D0%BE%D0%BD",
+        "drop": [
+            {
+                "name": "New Loka",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "래스본 헤드",
+        "description": "<p>A heavy Hammer exclusive to Archwing use, the Rathbone primarily deals  Impact damage, which is ideal for taking down Corpus shields. This weapon shares its own basic six combo with Centaur.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Rathbone",
+        "drop": [
+            {
+                "name": "New Loka",
+                "link": null
+            }
+        ]
+    },
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Rathbone Set.json
+++ b/queued_updates/items/Rathbone Set.json
@@ -1,0 +1,38 @@
+{
+    "_id": "582b0f8a0af25410b099f800",
+    "tags": [
+        "parts",
+        "archwing",
+        "set"
+    ],
+    "icon": "icons/en/Rathbone_Set.7e6a0db9a09fae95a9f6a4e96b1f0979.png",
+    "thumb": "icons/en/thumbs/Rathbone_Set.7e6a0db9a09fae95a9f6a4e96b1f0979.128x128.png",
+    "icon_format": "land",
+    "url_name": "rathbone_set",
+    "tradable": true,
+    "part_of_set": [
+        "582b0f8a0af25410b099f800",
+        "578d33bf34003bbbb9e20924",
+        "578d33bf34003bbbb9e20925"
+    ],
+    "set_root": true,
+    "en": {
+        "item_name": "Rathbone Set",
+        "description": "<p>A heavy Hammer exclusive to Archwing use, the Rathbone primarily deals  Impact damage, which is ideal for taking down Corpus shields. This weapon shares its own basic six combo with Centaur.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Rathbone",
+        "drop": []
+    },
+    "ru": {
+        "item_name": "Рэтбон Комплект",
+        "description": "<p>Используя реактивную силу Арчвинга, этот массивный молот разрушает всё на своём пути</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%A0%D1%8D%D1%82%D0%B1%D0%BE%D0%BD",
+        "drop": []
+    },
+    "ko": {
+        "item_name": "래스본 세트",
+        "description": "<p>A heavy Hammer exclusive to Archwing use, the Rathbone primarily deals  Impact damage, which is ideal for taking down Corpus shields. This weapon shares its own basic six combo with Centaur.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Rathbone",
+        "drop": []
+    },
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Rift Haven.json
+++ b/queued_updates/items/Rift Haven.json
@@ -1,0 +1,60 @@
+{
+    "_id": "5ce7fd87d23a3b00908c420e",
+    "tags": [
+        "mod",
+        "rare"
+    ],
+    "icon": "icons/en/Rift_Haven.84eb7632d0bd0b93a7a7173ea774f2b1.png",
+    "thumb": "icons/en/thumbs/Rift_Haven.84eb7632d0bd0b93a7a7173ea774f2b1.128x128.png",
+    "icon_format": "port",
+    "url_name": "rift_haven",
+    "tradable": true,
+    "en": {
+        "item_name": "Rift Haven",
+        "description": "<p>Banish Augment: Allies banished to the rift will have 10% of their Maximum Health restored.</p>",
+        "drop": [
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            },
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Укрытие Бездной",
+        "description": "<p>Banish Augment: Allies banished to the rift will have 10% of their Maximum Health restored.</p>",
+        "wiki_link": "https://warframe.fandom.com/ru/wiki/%D0%A3%D0%BA%D1%80%D1%8B%D1%82%D0%B8%D0%B5_%D0%91%D0%B5%D0%B7%D0%B4%D0%BD%D0%BE%D0%B9",
+        "icon": "icons/ru/Rift_Haven.a7c87a233b9132c26a83ec3e5e812f26.png",
+        "thumb": "icons/ru/thumbs/Rift_Haven.a7c87a233b9132c26a83ec3e5e812f26.128x128.png",
+        "drop": [
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            },
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "리프트 헤이븐",
+        "description": "<p>Banish Augment: Allies banished to the rift will have 10% of their Maximum Health restored.</p>",
+        "drop": [
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            },
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            }
+        ]
+    },
+    "rarity": "rare",
+    "mod_max_rank": 3,
+    "trading_tax": 8000
+}

--- a/queued_updates/items/Sancti Castanas.json
+++ b/queued_updates/items/Sancti Castanas.json
@@ -1,0 +1,47 @@
+{
+    "_id": "54aae2ace7798918750e63f2",
+    "tags": [
+        "syndicate",
+        "special weapons"
+    ],
+    "icon": "icons/en/sancti_castanas.1f0b15a73acc61516e6f3fbda5060cf6.png",
+    "thumb": "icons/en/thumbs/sancti_castanas.1f0b15a73acc61516e6f3fbda5060cf6.128x128.png",
+    "icon_format": "land",
+    "url_name": "sancti_castanas",
+    "tradable": true,
+    "en": {
+        "item_name": "Sancti Castanas",
+        "description": "<p>The Sancti Castanas are an exclusive version of the Castanas available only from New Loka. It has higher base damage, status and critical chance as well as innate Purity effect.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Sancti_Castanas",
+        "drop": [
+            {
+                "name": "New Loka",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Санкти кастанас",
+        "description": "<p>Эти дистанционно подрываемые электрические ловушки используются последователями Новой Локи для защиты своих храмов и святынь.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%A1%D0%B0%D0%BD%D0%BA%D1%82%D0%B8_%D0%BA%D0%B0%D1%81%D1%82%D0%B0%D0%BD%D0%B0%D1%81",
+        "drop": [
+            {
+                "name": "New Loka",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "생티 캐스타나스",
+        "description": "<p>The Sancti Castanas are an exclusive version of the Castanas available only from New Loka. It has higher base damage, status and critical chance as well as innate Purity effect.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Sancti_Castanas",
+        "drop": [
+            {
+                "name": "New Loka",
+                "link": null
+            }
+        ]
+    },
+    "mastery_level": 10,
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Sancti Magistar.json
+++ b/queued_updates/items/Sancti Magistar.json
@@ -1,0 +1,47 @@
+{
+    "_id": "57dbdc525e334907aa8edb5a",
+    "tags": [
+        "syndicate",
+        "melee"
+    ],
+    "icon": "icons/en/Sancti_Magistar.65c32b4c5b64ff010486af11e6c127c2.png",
+    "thumb": "icons/en/thumbs/Sancti_Magistar.65c32b4c5b64ff010486af11e6c127c2.128x128.png",
+    "icon_format": "land",
+    "url_name": "sancti_magistar",
+    "tradable": true,
+    "en": {
+        "item_name": "Sancti Magistar",
+        "description": "<p>The Sancti Magistar is the Syndicate variant of the Magistar, available from New Loka. It has the unique ability to heal allies when connecting with a melee charged attack, and also reduces damage from Status Effects for its wielder. </p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Sancti_Magistar",
+        "drop": [
+            {
+                "name": "New Loka",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Санкти магистр",
+        "description": "<p>Каждая усиленная атака преобразует боль противника в целительные импульсы, омывающие союзников. Также дарует сопротивление к эффектам статуса,  когда находится в руках.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%A1%D0%B0%D0%BD%D0%BA%D1%82%D0%B8_%D0%BC%D0%B0%D0%B3%D0%B8%D1%81%D1%82%D1%80",
+        "drop": [
+            {
+                "name": "New Loka",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "생티 마기스타",
+        "description": "<p>The Sancti Magistar is the Syndicate variant of the Magistar, available from New Loka. It has the unique ability to heal allies when connecting with a melee charged attack, and also reduces damage from Status Effects for its wielder. </p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Sancti_Magistar",
+        "drop": [
+            {
+                "name": "New Loka",
+                "link": null
+            }
+        ]
+    },
+    "mastery_level": 8,
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Sancti Tigris.json
+++ b/queued_updates/items/Sancti Tigris.json
@@ -1,0 +1,48 @@
+{
+    "_id": "55e797fde7798924a5a5650a",
+    "tags": [
+        "syndicate",
+        "weapon",
+        "special weapons"
+    ],
+    "icon": "icons/en/Sancti_Tigris.fd7c28cbc2f605d4a7d23ce1319ea87e.png",
+    "thumb": "icons/en/thumbs/Sancti_Tigris.fd7c28cbc2f605d4a7d23ce1319ea87e.128x128.png",
+    "icon_format": "land",
+    "url_name": "sancti_tigris",
+    "tradable": true,
+    "en": {
+        "item_name": "Sancti Tigris",
+        "description": "<p>The Sancti Tigris is a Tigris variant available only from New Loka. Featuring increased damage, reload speed, and critical chance, the Sancti Tigris also comes with an innate Purity effect.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Sancti_Tigris",
+        "drop": [
+            {
+                "name": "New Loka",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Санкти тигрис",
+        "description": "<p>Это особый Тигрис, воплощающий в себе буйство природы</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%A1%D0%B0%D0%BD%D0%BA%D1%82%D0%B8_%D1%82%D0%B8%D0%B3%D1%80%D0%B8%D1%81",
+        "drop": [
+            {
+                "name": "New Loka",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "생티 티그리스",
+        "description": "<p>The Sancti Tigris is a Tigris variant available only from New Loka. Featuring increased damage, reload speed, and critical chance, the Sancti Tigris also comes with an innate Purity effect.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Sancti_Tigris",
+        "drop": [
+            {
+                "name": "New Loka",
+                "link": null
+            }
+        ]
+    },
+    "mastery_level": 12,
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Scattered Justice.json
+++ b/queued_updates/items/Scattered Justice.json
@@ -1,0 +1,51 @@
+{
+    "_id": "54a74454e779892d5e5155f5",
+    "tags": [
+        "mod",
+        "weapons",
+        "rare"
+    ],
+    "icon": "icons/en/Scattered_Justice.b46113ecdbc04d327240cedec0e3b1f1.png",
+    "thumb": "icons/en/thumbs/Scattered_Justice.b46113ecdbc04d327240cedec0e3b1f1.128x128.png",
+    "icon_format": "port",
+    "url_name": "scattered_justice",
+    "tradable": true,
+    "en": {
+        "item_name": "Scattered Justice",
+        "description": "<p>The Scattered Justice mod is a Weapon Augment Mod that adds multishot and Justice specifically for the Hek. It increases multishot by 50% and Justice by 0.25 per rank, at a maximum of 200% and 1 at rank 3, respectively.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Scattered_Justice",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Переменная справедливость",
+        "description": "<p>Переменная Справедливость — мод-аугмент для дробовика Хек, который увеличивает шанс произведения дополнительного выстрела и даёт прирост Синдикат-эффекта - Правосудие.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%9F%D0%B5%D1%80%D0%B5%D0%BC%D0%B5%D0%BD%D0%BD%D0%B0%D1%8F_%D1%81%D0%BF%D1%80%D0%B0%D0%B2%D0%B5%D0%B4%D0%BB%D0%B8%D0%B2%D0%BE%D1%81%D1%82%D1%8C",
+        "icon": "icons/ru/Scattered_Justice.952071bd3461743095391ef3c4ed5f81.png",
+        "thumb": "icons/ru/thumbs/Scattered_Justice.952071bd3461743095391ef3c4ed5f81.128x128.png",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "스캐터드 저스티스",
+        "description": "<p>The Scattered Justice mod is a Weapon Augment Mod that adds multishot and Justice specifically for the Hek. It increases multishot by 50% and Justice by 0.25 per rank, at a maximum of 200% and 1 at rank 3, respectively.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Scattered_Justice",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            }
+        ]
+    },
+    "rarity": "rare",
+    "mod_max_rank": 3,
+    "trading_tax": 8000
+}

--- a/queued_updates/items/Secura Dual Cestra.json
+++ b/queued_updates/items/Secura Dual Cestra.json
@@ -1,0 +1,47 @@
+{
+    "_id": "54aae292e7798909064f1575",
+    "tags": [
+        "syndicate",
+        "special weapons"
+    ],
+    "icon": "icons/en/secura_dual_cestra.3d47a4ec6675ff774bb0da9b16c53e0e.png",
+    "thumb": "icons/en/thumbs/secura_dual_cestra.3d47a4ec6675ff774bb0da9b16c53e0e.128x128.png",
+    "icon_format": "land",
+    "url_name": "secura_dual_cestra",
+    "tradable": true,
+    "en": {
+        "item_name": "Secura Dual Cestra",
+        "description": "<p>The Secura Dual Cestra is a modified version of the Dual Cestra exclusive to The Perrin Sequence, featuring better stats and innate Sequence effect.  </p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Secura_Dual_Cestra",
+        "drop": [
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Парные цестры секура",
+        "description": "<p>Любимое второстепенное оружие оперативников Последовательности Перрина, эти пистолеты были модифицированы для улучшения эффективности и убийственного потенциала.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%9F%D0%B0%D1%80%D0%BD%D1%8B%D0%B5_%D1%86%D0%B5%D1%81%D1%82%D1%80%D1%8B_%D1%81%D0%B5%D0%BA%D1%83%D1%80%D0%B0",
+        "drop": [
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "세큐라 듀얼 세스트라",
+        "description": "<p>The Secura Dual Cestra is a modified version of the Dual Cestra exclusive to The Perrin Sequence, featuring better stats and innate Sequence effect.  </p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Secura_Dual_Cestra",
+        "drop": [
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "mastery_level": 10,
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Secura Lecta.json
+++ b/queued_updates/items/Secura Lecta.json
@@ -1,0 +1,47 @@
+{
+    "_id": "57dbdc525e334907aa8edb58",
+    "tags": [
+        "syndicate",
+        "melee"
+    ],
+    "icon": "icons/en/Secura_Lecta.44e35643f0208a0aa069fe393cd2e11b.png",
+    "thumb": "icons/en/thumbs/Secura_Lecta.44e35643f0208a0aa069fe393cd2e11b.128x128.png",
+    "icon_format": "land",
+    "url_name": "secura_lecta",
+    "tradable": true,
+    "en": {
+        "item_name": "Secura Lecta",
+        "description": "<p>The Secura Lecta is the Syndicate variant of the Lecta, exclusive to the Perrin Sequence, with the unique ability to double the amount of credits dropped by enemies it kills. </p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Secura_Lecta",
+        "drop": [
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Секура лекта",
+        "description": "<p>Избавьте противника от нечестно полученных кредитов: враги, убитые этим оружием, оставляют после себя удвоенное количество кредитов.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%A1%D0%B5%D0%BA%D1%83%D1%80%D0%B0_%D0%BB%D0%B5%D0%BA%D1%82%D0%B0",
+        "drop": [
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "세큐라 렉타",
+        "description": "<p>The Secura Lecta is the Syndicate variant of the Lecta, exclusive to the Perrin Sequence, with the unique ability to double the amount of credits dropped by enemies it kills. </p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Secura_Lecta",
+        "drop": [
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "mastery_level": 8,
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Secura Penta.json
+++ b/queued_updates/items/Secura Penta.json
@@ -1,0 +1,48 @@
+{
+    "_id": "55e797e7e779892497cdf785",
+    "tags": [
+        "syndicate",
+        "weapon",
+        "special weapons"
+    ],
+    "icon": "icons/en/Secura_Penta.46a8573433a7ddec1f7e7c1bccb4d5ac.png",
+    "thumb": "icons/en/thumbs/Secura_Penta.46a8573433a7ddec1f7e7c1bccb4d5ac.128x128.png",
+    "icon_format": "land",
+    "url_name": "secura_penta",
+    "tradable": true,
+    "en": {
+        "item_name": "Secura Penta",
+        "description": "<p>The Secura Penta is the Perrin Sequence exclusive version of the Penta grenade launcher. Compared to the regular Penta, it has a significantly increased rate of fire, increased magazine capacity, and slightly increased explosion damage. It also comes with an innate Sequence effect.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Secura_Penta",
+        "drop": [
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Секура пента",
+        "description": "<p>Беспощадное и эффективное, как свободный рынок оружие.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%A1%D0%B5%D0%BA%D1%83%D1%80%D0%B0_%D0%BF%D0%B5%D0%BD%D1%82%D0%B0",
+        "drop": [
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "세큐라 펜타",
+        "description": "<p>The Secura Penta is the Perrin Sequence exclusive version of the Penta grenade launcher. Compared to the regular Penta, it has a significantly increased rate of fire, increased magazine capacity, and slightly increased explosion damage. It also comes with an innate Sequence effect.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Secura_Penta",
+        "drop": [
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "mastery_level": 12,
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Sequence Burn.json
+++ b/queued_updates/items/Sequence Burn.json
@@ -1,0 +1,51 @@
+{
+    "_id": "54a74455e779892d5e515699",
+    "tags": [
+        "mod",
+        "weapons",
+        "rare"
+    ],
+    "icon": "icons/en/Sequence_Burn.e9651c33bc02879c407f18d391667aa9.png",
+    "thumb": "icons/en/thumbs/Sequence_Burn.e9651c33bc02879c407f18d391667aa9.128x128.png",
+    "icon_format": "port",
+    "url_name": "sequence_burn",
+    "tradable": true,
+    "en": {
+        "item_name": "Sequence Burn",
+        "description": "<p>The Sequence Burn mod is a Weapon Augment Mod that increases weapon range and Sequence specifically for the Spectra. It increases the range by 5 and Sequence by 0.25 per rank, at a maximum of 20 and 1 at rank 3, respectively.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Sequence_Burn",
+        "drop": [
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Последовательное горение",
+        "description": "<p>Последовательное Горение — мод-аугмент для пистолета Спектра, который увеличивает радиус поражения и даёт прирост Синдикат-эффекта - Последовательность.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%9F%D0%BE%D1%81%D0%BB%D0%B5%D0%B4%D0%BE%D0%B2%D0%B0%D1%82%D0%B5%D0%BB%D1%8C%D0%BD%D0%BE%D0%B5_%D0%B3%D0%BE%D1%80%D0%B5%D0%BD%D0%B8%D0%B5",
+        "icon": "icons/ru/Sequence_Burn.3696a9042fc04349da96190284ff3ab2.png",
+        "thumb": "icons/ru/thumbs/Sequence_Burn.3696a9042fc04349da96190284ff3ab2.128x128.png",
+        "drop": [
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "시퀀스 번",
+        "description": "<p>The Sequence Burn mod is a Weapon Augment Mod that increases weapon range and Sequence specifically for the Spectra. It increases the range by 5 and Sequence by 0.25 per rank, at a maximum of 20 and 1 at rank 3, respectively.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Sequence_Burn",
+        "drop": [
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "rarity": "rare",
+    "mod_max_rank": 3,
+    "trading_tax": 8000
+}

--- a/queued_updates/items/Shattering Justice.json
+++ b/queued_updates/items/Shattering Justice.json
@@ -1,0 +1,51 @@
+{
+    "_id": "54a74454e779892d5e5155a6",
+    "tags": [
+        "mod",
+        "weapons",
+        "rare"
+    ],
+    "icon": "icons/en/Shattering_Justice.12be7d056cf4cd66d202b72eb1ca480e.png",
+    "thumb": "icons/en/thumbs/Shattering_Justice.12be7d056cf4cd66d202b72eb1ca480e.128x128.png",
+    "icon_format": "port",
+    "url_name": "shattering_justice",
+    "tradable": true,
+    "en": {
+        "item_name": "Shattering Justice",
+        "description": "<p>The Shattering Justice mod is a Weapon Augment Mod that adds status chance and Justice specifically for the Sobek. It increases status chance by 5 and Justice by 0.25 per rank, at a maximum of 20 and 1 at rank 3, respectively.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Shattering_Justice",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Раскалывающая справедливость",
+        "description": "<p>Раскалывающая справедливость — мод-аугмент для оружия Собек, который увеличивает шанс срабатывания эффекта статуса и даёт прирост Синдикат-эффекта - Правосудие.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%A0%D0%B0%D1%81%D0%BA%D0%B0%D0%BB%D1%8B%D0%B2%D0%B0%D1%8E%D1%89%D0%B5%D0%B5_%D0%BF%D1%80%D0%B0%D0%B2%D0%BE%D1%81%D1%83%D0%B4%D0%B8%D0%B5",
+        "icon": "icons/ru/Shattering_Justice.a37eb70d577eea758df3c927c5187f09.png",
+        "thumb": "icons/ru/thumbs/Shattering_Justice.a37eb70d577eea758df3c927c5187f09.128x128.png",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "섀터링 저스티스",
+        "description": "<p>The Shattering Justice mod is a Weapon Augment Mod that adds status chance and Justice specifically for the Sobek. It increases status chance by 5 and Justice by 0.25 per rank, at a maximum of 20 and 1 at rank 3, respectively.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Shattering_Justice",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            }
+        ]
+    },
+    "rarity": "rare",
+    "mod_max_rank": 3,
+    "trading_tax": 8000
+}

--- a/queued_updates/items/Stinging Truth.json
+++ b/queued_updates/items/Stinging Truth.json
@@ -1,0 +1,51 @@
+{
+    "_id": "54a74455e779892d5e5156d2",
+    "tags": [
+        "mod",
+        "weapons",
+        "rare"
+    ],
+    "icon": "icons/en/Stinging_Truth.90e5015f6f6f08638553b8f73b857b49.png",
+    "thumb": "icons/en/thumbs/Stinging_Truth.90e5015f6f6f08638553b8f73b857b49.128x128.png",
+    "icon_format": "port",
+    "url_name": "stinging_truth",
+    "tradable": true,
+    "en": {
+        "item_name": "Stinging Truth",
+        "description": "<p>The Stinging Truth mod is a Weapon Augment Mod that increases magazine capacity and Truth specifically for the Viper. It increases magazine capacity by 10 and Truth by 0.25 per rank, at a maximum of 40 and 1 at rank 3, respectively.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Stinging_Truth",
+        "drop": [
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Обжигающая правда",
+        "description": "<p>Обжигающая Правда — мод-аугмент для вторичного оружия Гадюка, который увеличивает вместимость магазина и даёт прирост Синдикат-эффекта - Правда.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%9E%D0%B1%D0%B6%D0%B8%D0%B3%D0%B0%D1%8E%D1%89%D0%B0%D1%8F_%D0%BF%D1%80%D0%B0%D0%B2%D0%B4%D0%B0",
+        "icon": "icons/ru/Stinging_Truth.a3bd58fcbf71bc7afe0e6281153bd574.png",
+        "thumb": "icons/ru/thumbs/Stinging_Truth.a3bd58fcbf71bc7afe0e6281153bd574.128x128.png",
+        "drop": [
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "스팅잉 트루스",
+        "description": "<p>The Stinging Truth mod is a Weapon Augment Mod that increases magazine capacity and Truth specifically for the Viper. It increases magazine capacity by 10 and Truth by 0.25 per rank, at a maximum of 40 and 1 at rank 3, respectively.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Stinging_Truth",
+        "drop": [
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            }
+        ]
+    },
+    "rarity": "rare",
+    "mod_max_rank": 3,
+    "trading_tax": 8000
+}

--- a/queued_updates/items/Stockpiled Blight.json
+++ b/queued_updates/items/Stockpiled Blight.json
@@ -1,0 +1,62 @@
+{
+    "_id": "5911f11d97a0add8e9d5da4f",
+    "tags": [
+        "mod",
+        "kunai"
+    ],
+    "icon": "icons/en/Stockpiled_Blight.3231785f2d66f6d8a1a452aacffb0d3d.png",
+    "thumb": "icons/en/thumbs/Stockpiled_Blight.3231785f2d66f6d8a1a452aacffb0d3d.128x128.png",
+    "icon_format": "port",
+    "url_name": "stockpiled_blight",
+    "tradable": true,
+    "en": {
+        "item_name": "Stockpiled Blight",
+        "description": "<p>Stockpiled Blight Increases the magazine size of the Kunai and also adds a Blight effect.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Stockpiled_Blight",
+        "drop": [
+            {
+                "name": "Operation: Ambulas Reborn",
+                "link": null
+            },
+            {
+                "name": "Red Veil",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Концентрированная Отрава",
+        "description": "<p>Концентрированная Отрава — Мод-Аугмент для оружия Кунаи, который увеличивает обойму и даёт прирост синдикат-эффекта — Гниль.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%9A%D0%BE%D0%BD%D1%86%D0%B5%D0%BD%D1%82%D1%80%D0%B8%D1%80%D0%BE%D0%B2%D0%B0%D0%BD%D0%BD%D0%B0%D1%8F_%D0%9E%D1%82%D1%80%D0%B0%D0%B2%D0%B0",
+        "icon": "icons/ru/Stockpiled_Blight.55f975934823d9ed93cf1b361315c198.png",
+        "thumb": "icons/ru/thumbs/Stockpiled_Blight.55f975934823d9ed93cf1b361315c198.128x128.png",
+        "drop": [
+            {
+                "name": "Operation: Ambulas Reborn",
+                "link": null
+            },
+            {
+                "name": "Red Veil",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "스톡파일드 블라이트",
+        "description": "<p>Stockpiled Blight Increases the magazine size of the Kunai and also adds a Blight effect.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Stockpiled_Blight",
+        "drop": [
+            {
+                "name": "Operation: Ambulas Reborn",
+                "link": null
+            },
+            {
+                "name": "Red Veil",
+                "link": null
+            }
+        ]
+    },
+    "rarity": "rare",
+    "mod_max_rank": 3,
+    "trading_tax": 8000
+}

--- a/queued_updates/items/Synoid Gammacor.json
+++ b/queued_updates/items/Synoid Gammacor.json
@@ -1,0 +1,47 @@
+{
+    "_id": "54aae283e779897f276a5768",
+    "tags": [
+        "syndicate",
+        "special weapons"
+    ],
+    "icon": "icons/en/synoid_gammacor.16811422b2fab432718fd630acbf5358.png",
+    "thumb": "icons/en/thumbs/synoid_gammacor.16811422b2fab432718fd630acbf5358.128x128.png",
+    "icon_format": "land",
+    "url_name": "synoid_gammacor",
+    "tradable": true,
+    "en": {
+        "item_name": "Synoid Gammacor",
+        "description": "<p>The Synoid Gammacor is an exclusive version of the Gammacor available only from Cephalon Suda, possessing better stats as well as innate Entropy effect.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Synoid_Gammacor",
+        "drop": [
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Синоидальный гаммакор",
+        "description": "<p>Развертываемый Цефалоном Суда, этот разрушительный аналитический инструмент распыляет свою цель ради получения важных данных.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%A1%D0%B8%D0%BD%D0%BE%D0%B8%D0%B4%D0%B0%D0%BB%D1%8C%D0%BD%D1%8B%D0%B9_%D0%B3%D0%B0%D0%BC%D0%BC%D0%B0%D0%BA%D0%BE%D1%80",
+        "drop": [
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "사이노이드 감마코어",
+        "description": "<p>The Synoid Gammacor is an exclusive version of the Gammacor available only from Cephalon Suda, possessing better stats as well as innate Entropy effect.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Synoid_Gammacor",
+        "drop": [
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            }
+        ]
+    },
+    "mastery_level": 7,
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Synoid Heliocor.json
+++ b/queued_updates/items/Synoid Heliocor.json
@@ -1,0 +1,47 @@
+{
+    "_id": "57dbdc525e334907aa8edb57",
+    "tags": [
+        "syndicate",
+        "melee"
+    ],
+    "icon": "icons/en/synoid_heliocor.c2b16872e85db1f95ba4766f3edda84d.png",
+    "thumb": "icons/en/thumbs/synoid_heliocor.c2b16872e85db1f95ba4766f3edda84d.128x128.png",
+    "icon_format": "land",
+    "url_name": "synoid_heliocor",
+    "tradable": true,
+    "en": {
+        "item_name": "Synoid Heliocor",
+        "description": "<p>The Synoid Heliocor is the Syndicate variant of the Heliocor, unique to Cephalon Suda. In addition to its ability to scan targets it kills into the Codex, this Synoid version also creates a friendly Specter of an enemy it kills with a channeled strike, so long as said enemy's Codex entry is complete.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Synoid_Heliocor",
+        "drop": [
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Синоидальный гелиокор",
+        "description": "<p>Этот \"умный молот\" захватывает врага, убитого атакой при концентрации, и проецирует его в качестве союзника. Любой летальный удар, нанесенный этим молотом совершает сканирование для кодекса.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%A1%D0%B8%D0%BD%D0%BE%D0%B8%D0%B4%D0%B0%D0%BB%D1%8C%D0%BD%D1%8B%D0%B9_%D0%B3%D0%B5%D0%BB%D0%B8%D0%BE%D0%BA%D0%BE%D1%80",
+        "drop": [
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "사이노이드 헬리오코어",
+        "description": "<p>The Synoid Heliocor is the Syndicate variant of the Heliocor, unique to Cephalon Suda. In addition to its ability to scan targets it kills into the Codex, this Synoid version also creates a friendly Specter of an enemy it kills with a channeled strike, so long as said enemy's Codex entry is complete.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Synoid_Heliocor",
+        "drop": [
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            }
+        ]
+    },
+    "mastery_level": 11,
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Synoid Simulor.json
+++ b/queued_updates/items/Synoid Simulor.json
@@ -1,0 +1,48 @@
+{
+    "_id": "55e797dde77989248e0e6d54",
+    "tags": [
+        "syndicate",
+        "weapon",
+        "special weapons"
+    ],
+    "icon": "icons/en/Synoid_Simulor.9daa9583eb6d6d86f549933b6d0ff163.png",
+    "thumb": "icons/en/thumbs/Synoid_Simulor.9daa9583eb6d6d86f549933b6d0ff163.128x128.png",
+    "icon_format": "land",
+    "url_name": "synoid_simulor",
+    "tradable": true,
+    "en": {
+        "item_name": "Synoid Simulor",
+        "description": "<p>The Synoid Simulor is a custom-version of the Simulor available only from Cephalon Suda, which launches orbs of gravitational force. These orbs can be manipulated to produce either explosions or implosions.  Featuring improved stats, the Synoid Simulor also features innate Entropy effect.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Synoid_Simulor",
+        "drop": [
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Синоидальный симулор",
+        "description": "<p>Цефалон Суда создала этот Симулор, чтобы удовлетворить своё любопытство.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%A1%D0%B8%D0%BD%D0%BE%D0%B8%D0%B4%D0%B0%D0%BB%D1%8C%D0%BD%D1%8B%D0%B9_%D1%81%D0%B8%D0%BC%D1%83%D0%BB%D0%BE%D1%80",
+        "drop": [
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "사이노이드 시뮬러",
+        "description": "<p>The Synoid Simulor is a custom-version of the Simulor available only from Cephalon Suda, which launches orbs of gravitational force. These orbs can be manipulated to produce either explosions or implosions.  Featuring improved stats, the Synoid Simulor also features innate Entropy effect.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Synoid_Simulor",
+        "drop": [
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            }
+        ]
+    },
+    "mastery_level": 12,
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Teeming Virulence.json
+++ b/queued_updates/items/Teeming Virulence.json
@@ -1,0 +1,63 @@
+{
+    "_id": "5cb04869fc2db2068006980f",
+    "tags": [
+        "mod",
+        "rare",
+        "nidus"
+    ],
+    "icon": "icons/en/Teeming_Virulence.fa710f9e32c92ec59ee9bd77215811d0.png",
+    "thumb": "icons/en/thumbs/Teeming_Virulence.fa710f9e32c92ec59ee9bd77215811d0.128x128.png",
+    "icon_format": "port",
+    "url_name": "teeming_virulence",
+    "tradable": true,
+    "en": {
+        "item_name": "Teeming Virulence",
+        "description": "<p>Teeming Virulence is a Warframe Augment Mod for Nidus that grants increased critical chance of Nidus' primary weapon upon hitting 4 enemies with Virulence.</p>",
+        "wiki_link": "https://warframe.fandom.com/wiki/Teeming_Virulence",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            },
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Массовая Зараза",
+        "description": "<p>Массовая Зараза — мод-аугмент для Варфрейма Нидус, изменяющий способность Зараза. Попадание по четырём врагам добавит основному оружию дополнительный шанс нанесения критического урона в течение ограниченного времени.</p>",
+        "wiki_link": "https://warframe.fandom.com/ru/wiki/%D0%93%D1%80%D0%B0%D0%BD%D0%B0%D1%82%D1%8B_%D1%81_%D0%9D%D0%B0%D0%BF%D0%B0%D0%BB%D0%BC%D0%BE%D0%BC",
+        "icon": "icons/ru/Teeming_Virulence.a16ad556043256118492083ff5ad3ca4.png",
+        "thumb": "icons/ru/thumbs/Teeming_Virulence.a16ad556043256118492083ff5ad3ca4.128x128.png",
+        "drop": [
+            {
+                "name": "Стальной Меридиан",
+                "link": null
+            },
+            {
+                "name": "Последовательность Перрина",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "티밍 비럴런스",
+        "description": "<p>Teeming Virulence is a Warframe Augment Mod for Nidus that grants increased critical chance of Nidus' primary weapon upon hitting 4 enemies with Virulence.</p>",
+        "wiki_link": "https://warframe.fandom.com/wiki/Teeming_Virulence",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            },
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "rarity": "rare",
+    "mod_max_rank": 3,
+    "trading_tax": 8000
+}

--- a/queued_updates/items/Telos Akbolto.json
+++ b/queued_updates/items/Telos Akbolto.json
@@ -1,0 +1,47 @@
+{
+    "_id": "54aae272e7798975bbba5f07",
+    "tags": [
+        "syndicate",
+        "special weapons"
+    ],
+    "icon": "icons/en/telos_akbolto.5ff5d38fdf6d7a931cd907ffae3d9e7d.png",
+    "thumb": "icons/en/thumbs/telos_akbolto.5ff5d38fdf6d7a931cd907ffae3d9e7d.128x128.png",
+    "icon_format": "land",
+    "url_name": "telos_akbolto",
+    "tradable": true,
+    "en": {
+        "item_name": "Telos Akbolto",
+        "description": "<p>The Telos Akbolto is an exclusive version of the Akbolto available only from the Arbiters of Hexis. Featuring improved stats, the Telos Akbolto also features innate Truth effect.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Telos_Akbolto",
+        "drop": [
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Телос акболто",
+        "description": "<p>Для Арбитров Гексиса эти пистолеты - больше, чем просто оружие; они символ правды и дисциплины.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%A2%D0%B5%D0%BB%D0%BE%D1%81_%D0%B0%D0%BA%D0%B1%D0%BE%D0%BB%D1%82%D0%BE",
+        "drop": [
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "텔로스 아크볼토",
+        "description": "<p>The Telos Akbolto is an exclusive version of the Akbolto available only from the Arbiters of Hexis. Featuring improved stats, the Telos Akbolto also features innate Truth effect.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Telos_Akbolto",
+        "drop": [
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            }
+        ]
+    },
+    "mastery_level": 11,
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Telos Boltace.json
+++ b/queued_updates/items/Telos Boltace.json
@@ -1,0 +1,47 @@
+{
+    "_id": "57dbdc525e334907aa8edb56",
+    "tags": [
+        "syndicate",
+        "melee"
+    ],
+    "icon": "icons/en/telos_boltace.9dc9593274da1116201b84905a53f506.png",
+    "thumb": "icons/en/thumbs/telos_boltace.9dc9593274da1116201b84905a53f506.128x128.png",
+    "icon_format": "land",
+    "url_name": "telos_boltace",
+    "tradable": true,
+    "en": {
+        "item_name": "Telos Boltace",
+        "description": "<p>The Telos Boltace is the Syndicate variant of the Boltace, available only from the Arbiters of Hexis. On slide attacks, the weapon produces an energy wave from the player that spreads in all directions, dealing high damage to nearby enemies. Additionally, switching to the Telos Boltace increases the velocity or duration of certain Maneuvers.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Telos_Boltace",
+        "drop": [
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Телос болтэс",
+        "description": "<p>Раздвиньте границы смертоносности Тэнно, атакуя жестокими ударами с разворота, наносящими урон всем в радиусе поражения.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%A2%D0%B5%D0%BB%D0%BE%D1%81_%D0%B1%D0%BE%D0%BB%D1%82%D1%8D%D1%81",
+        "drop": [
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "텔로스 볼테이스",
+        "description": "<p>The Telos Boltace is the Syndicate variant of the Boltace, available only from the Arbiters of Hexis. On slide attacks, the weapon produces an energy wave from the player that spreads in all directions, dealing high damage to nearby enemies. Additionally, switching to the Telos Boltace increases the velocity or duration of certain Maneuvers.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Telos_Boltace",
+        "drop": [
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            }
+        ]
+    },
+    "mastery_level": 11,
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Telos Boltor.json
+++ b/queued_updates/items/Telos Boltor.json
@@ -1,0 +1,48 @@
+{
+    "_id": "55e797d2e7798924849dd9f0",
+    "tags": [
+        "syndicate",
+        "weapon",
+        "special weapons"
+    ],
+    "icon": "icons/en/Telos_Boltor.9a109e6b666017c81b2402e7031243b5.png",
+    "thumb": "icons/en/thumbs/Telos_Boltor.9a109e6b666017c81b2402e7031243b5.128x128.png",
+    "icon_format": "land",
+    "url_name": "telos_boltor",
+    "tradable": true,
+    "en": {
+        "item_name": "Telos Boltor",
+        "description": "<p>The Telos Boltor is an exclusive version of the Boltor available only from the Arbiters of Hexis. Featuring improved stats and an additional polarity slot, the Telos Boltor also features innate Truth effect.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Telos_Boltor",
+        "drop": [
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Телос болтор",
+        "description": "<p>Приведи правосудие в исполнение винтовкой, созданной Арбитрами Гексиса</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%A2%D0%B5%D0%BB%D0%BE%D1%81_%D0%B1%D0%BE%D0%BB%D1%82%D0%BE%D1%80",
+        "drop": [
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "텔로스 볼터",
+        "description": "<p>The Telos Boltor is an exclusive version of the Boltor available only from the Arbiters of Hexis. Featuring improved stats and an additional polarity slot, the Telos Boltor also features innate Truth effect.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Telos_Boltor",
+        "drop": [
+            {
+                "name": "Arbiters of Hexis",
+                "link": null
+            }
+        ]
+    },
+    "mastery_level": 12,
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Toxic Blight.json
+++ b/queued_updates/items/Toxic Blight.json
@@ -1,0 +1,51 @@
+{
+    "_id": "54a74454e779892d5e5155bb",
+    "tags": [
+        "mod",
+        "weapons",
+        "rare"
+    ],
+    "icon": "icons/en/Toxic_Blight.2d55757c9dcf2a97b13302a7d7ae42b4.png",
+    "thumb": "icons/en/thumbs/Toxic_Blight.2d55757c9dcf2a97b13302a7d7ae42b4.128x128.png",
+    "icon_format": "port",
+    "url_name": "toxic_blight",
+    "tradable": true,
+    "en": {
+        "item_name": "Toxic Blight",
+        "description": "<p>The Toxic Blight mod is a Weapon Augment Mod that increases  Toxin damage and Blight specifically for the Mire. It increases  Toxin by 25% and Blight by 0.25 per rank, at a maximum of 100% and 1 at rank 3, respectively.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Toxic_Blight",
+        "drop": [
+            {
+                "name": "Red Veil",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Токсичная гниль",
+        "description": "<p>Токсичная Гниль — мод-аугмент для оружия Майр, который увеличивает  токсичный урон и даёт прирост Синдикат-эффекта - Гниль.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%A2%D0%BE%D0%BA%D1%81%D0%B8%D1%87%D0%BD%D0%B0%D1%8F_%D0%B3%D0%BD%D0%B8%D0%BB%D1%8C",
+        "icon": "icons/ru/Toxic_Blight.9ef51fd489fe22fbe5b60e220e651400.png",
+        "thumb": "icons/ru/thumbs/Toxic_Blight.9ef51fd489fe22fbe5b60e220e651400.128x128.png",
+        "drop": [
+            {
+                "name": "Red Veil",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "톡식 블라이트",
+        "description": "<p>The Toxic Blight mod is a Weapon Augment Mod that increases  Toxin damage and Blight specifically for the Mire. It increases  Toxin by 25% and Blight by 0.25 per rank, at a maximum of 100% and 1 at rank 3, respectively.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Toxic_Blight",
+        "drop": [
+            {
+                "name": "Red Veil",
+                "link": null
+            }
+        ]
+    },
+    "rarity": "rare",
+    "mod_max_rank": 3,
+    "trading_tax": 8000
+}

--- a/queued_updates/items/Toxic Sequence.json
+++ b/queued_updates/items/Toxic Sequence.json
@@ -1,0 +1,51 @@
+{
+    "_id": "54a74454e779892d5e5155e3",
+    "tags": [
+        "mod",
+        "weapons",
+        "rare"
+    ],
+    "icon": "icons/en/Toxic_Sequence.bab0370da343ca58b4b92fca65b1da6a.png",
+    "thumb": "icons/en/thumbs/Toxic_Sequence.bab0370da343ca58b4b92fca65b1da6a.128x128.png",
+    "icon_format": "port",
+    "url_name": "toxic_sequence",
+    "tradable": true,
+    "en": {
+        "item_name": "Toxic Sequence",
+        "description": "<p>The Toxic Sequence mod is a Weapon Augment Mod that increases status duration and Sequence specifically for the Acrid. It increases status duration by 50% and Sequence by 0.25 per rank, at a maximum of 200% and 1 at rank 3, respectively.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Toxic_Sequence",
+        "drop": [
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Токсичная последовательность",
+        "description": "<p>Токсичная Последовательность — мод-аугмент для оружия Акрид, который увеличивает время продолжительности эффекта статуса и даёт прирост синдикат-эффекта -  Последовательность.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%A2%D0%BE%D0%BA%D1%81%D0%B8%D1%87%D0%BD%D0%B0%D1%8F_%D0%BF%D0%BE%D1%81%D0%BB%D0%B5%D0%B4%D0%BE%D0%B2%D0%B0%D1%82%D0%B5%D0%BB%D1%8C%D0%BD%D0%BE%D1%81%D1%82%D1%8C",
+        "icon": "icons/ru/Toxic_Sequence.7970729439a018f88988adaba1e4355f.png",
+        "thumb": "icons/ru/thumbs/Toxic_Sequence.7970729439a018f88988adaba1e4355f.128x128.png",
+        "drop": [
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "톡식 시퀀스",
+        "description": "<p>The Toxic Sequence mod is a Weapon Augment Mod that increases status duration and Sequence specifically for the Acrid. It increases status duration by 50% and Sequence by 0.25 per rank, at a maximum of 200% and 1 at rank 3, respectively.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Toxic_Sequence",
+        "drop": [
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "rarity": "rare",
+    "mod_max_rank": 3,
+    "trading_tax": 8000
+}

--- a/queued_updates/items/Vaykor Hek.json
+++ b/queued_updates/items/Vaykor Hek.json
@@ -1,0 +1,48 @@
+{
+    "_id": "55e797c8e779892474566543",
+    "tags": [
+        "syndicate",
+        "weapon",
+        "special weapons"
+    ],
+    "icon": "icons/en/Vaykor_Hek.2276a61ab8713d1b35e651db67402ca9.png",
+    "thumb": "icons/en/thumbs/Vaykor_Hek.2276a61ab8713d1b35e651db67402ca9.128x128.png",
+    "icon_format": "land",
+    "url_name": "vaykor_hek",
+    "tradable": true,
+    "en": {
+        "item_name": "Vaykor Hek",
+        "description": "<p>The Vaykor Hek is a Hek variant available only from Steel Meridian. Boasting double the magazine capacity of the base variant, a faster rate of fire, and an increased critical chance, the Vaykor Hek also comes with an innate Justice effect. It does, however, take slightly longer to reload than the base variant.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Vaykor_Hek",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Вэйкор хек",
+        "description": "<p>Выкованный в огне повстанческой войны, этот дробовик является инструментом освобождения</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%92%D1%8D%D0%B9%D0%BA%D0%BE%D1%80_%D1%85%D0%B5%D0%BA",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "베이코어 헥",
+        "description": "<p>The Vaykor Hek is a Hek variant available only from Steel Meridian. Boasting double the magazine capacity of the base variant, a faster rate of fire, and an increased critical chance, the Vaykor Hek also comes with an innate Justice effect. It does, however, take slightly longer to reload than the base variant.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Vaykor_Hek",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            }
+        ]
+    },
+    "mastery_level": 12,
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Vaykor Marelok.json
+++ b/queued_updates/items/Vaykor Marelok.json
@@ -1,0 +1,47 @@
+{
+    "_id": "54aae25de7798968b372a4e1",
+    "tags": [
+        "syndicate",
+        "special weapons"
+    ],
+    "icon": "icons/en/vaykor_marelok.592a0473da4aaf70a4864b0ca864a17f.png",
+    "thumb": "icons/en/thumbs/vaykor_marelok.592a0473da4aaf70a4864b0ca864a17f.128x128.png",
+    "icon_format": "land",
+    "url_name": "vaykor_marelok",
+    "tradable": true,
+    "en": {
+        "item_name": "Vaykor Marelok",
+        "description": "<p>The Vaykor Marelok is a Marelok variant available only from Steel Meridian. Boasting a larger magazine, critical chance and status chance, the Vaykor Marelok also comes with an innate Justice effect.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Vaykor_Marelok",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Вэйкор мэрлок",
+        "description": "<p>Снят с тел поверженных командиров Гринир и перестроен для повышения эффективности и надежности.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%92%D1%8D%D0%B9%D0%BA%D0%BE%D1%80_%D0%BC%D1%8D%D1%80%D0%BB%D0%BE%D0%BA",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "베이코어 메어락",
+        "description": "<p>The Vaykor Marelok is a Marelok variant available only from Steel Meridian. Boasting a larger magazine, critical chance and status chance, the Vaykor Marelok also comes with an innate Justice effect.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Vaykor_Marelok",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            }
+        ]
+    },
+    "mastery_level": 10,
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Vaykor Sydon.json
+++ b/queued_updates/items/Vaykor Sydon.json
@@ -1,0 +1,47 @@
+{
+    "_id": "57dbdc525e334907aa8edb55",
+    "tags": [
+        "syndicate",
+        "melee"
+    ],
+    "icon": "icons/en/vaykor_sydon.d83d27c1e7742988b0d4aeb9c39985bd.png",
+    "thumb": "icons/en/thumbs/vaykor_sydon.d83d27c1e7742988b0d4aeb9c39985bd.128x128.png",
+    "icon_format": "land",
+    "url_name": "vaykor_sydon",
+    "tradable": true,
+    "en": {
+        "item_name": "Vaykor Sydon",
+        "description": "<p>The Vaykor Sydon is the Syndicate variant of the Sydon, available from Steel Meridian. It has the unique ability to store charges when blocking, which can be released as a Radial Blind once full.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Vaykor_Sydon",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Вэйкор Сидон",
+        "description": "<p>Справедливость ослепляет. Каждый заблокированный удар заряжает Ослепляющий Свет, при полной зарядке перестаньте блокировать, чтобы высвободить его.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%92%D1%8D%D0%B9%D0%BA%D0%BE%D1%80_%D1%81%D0%B8%D0%B4%D0%BE%D0%BD",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "베이코어 사이돈",
+        "description": "<p>The Vaykor Sydon is the Syndicate variant of the Sydon, available from Steel Meridian. It has the unique ability to store charges when blocking, which can be released as a Radial Blind once full.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Vaykor_Sydon",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            }
+        ]
+    },
+    "mastery_level": 11,
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Velocitus Barrel.json
+++ b/queued_updates/items/Velocitus Barrel.json
@@ -1,0 +1,55 @@
+{
+    "_id": "5783beebd9b6753790c89e88",
+    "tags": [
+        "parts",
+        "archwing",
+        "barrel"
+    ],
+    "icon": "icons/en/Velocitus_Set.0e2289bd3cc8bba9a0393d1fad061ab6.png",
+    "thumb": "icons/en/thumbs/Velocitus_Set.0e2289bd3cc8bba9a0393d1fad061ab6.128x128.png",
+    "icon_format": "land",
+    "sub_icon": "sub_icons/barrel_128x128.png",
+    "url_name": "velocitus_barrel",
+    "tradable": true,
+    "part_of_set": [
+        "582b0f850af25410b099f7f8",
+        "5783beebd9b6753790c89e88",
+        "5783bf0ad9b6753790c89e89",
+        "5783bf10d9b6753790c89e8a"
+    ],
+    "set_root": false,
+    "en": {
+        "item_name": "Velocitus Barrel",
+        "description": "<p>The Velocitus is an Archwing Gauss-gun that deals heavy charged shot damage. It is the first Archwing weapon to have base  Magnetic damage. </p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Velocitus",
+        "drop": [
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Велоцитус Ствол",
+        "description": "<p>Полностью заряженный, магнитный ствол Велоцитуса разгоняет металлическую болванку до огромных скоростей, позволяя ей пробивать дыры в броне и разрушать ее.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%92%D0%B5%D0%BB%D0%BE%D1%86%D0%B8%D1%82%D1%83%D1%81",
+        "drop": [
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "벨로시투스 배럴",
+        "description": "<p>The Velocitus is an Archwing Gauss-gun that deals heavy charged shot damage. It is the first Archwing weapon to have base  Magnetic damage. </p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Velocitus",
+        "drop": [
+            {
+                "name": "Cephalon Suda",
+                "link": null
+            }
+        ]
+    },
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Velocitus Receiver.json
+++ b/queued_updates/items/Velocitus Receiver.json
@@ -1,0 +1,55 @@
+{
+    "_id": "5783bf0ad9b6753790c89e89",
+    "tags": [
+        "parts",
+        "archwing",
+        "receiver"
+    ],
+    "icon": "icons/en/Velocitus_Set.0e2289bd3cc8bba9a0393d1fad061ab6.png",
+    "thumb": "icons/en/thumbs/Velocitus_Set.0e2289bd3cc8bba9a0393d1fad061ab6.128x128.png",
+    "icon_format": "land",
+    "sub_icon": "sub_icons/receiver_128x128.png",
+    "url_name": "velocitus_receiver",
+    "tradable": true,
+    "part_of_set": [
+        "582b0f850af25410b099f7f8",
+        "5783beebd9b6753790c89e88",
+        "5783bf0ad9b6753790c89e89",
+        "5783bf10d9b6753790c89e8a"
+    ],
+    "set_root": false,
+    "en": {
+        "item_name": "Velocitus Receiver",
+        "description": "<p>The Velocitus is an Archwing Gauss-gun that deals heavy charged shot damage. It is the first Archwing weapon to have base  Magnetic damage. </p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Velocitus",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Велоцитус Приемник",
+        "description": "<p>Полностью заряженный, магнитный ствол Велоцитуса разгоняет металлическую болванку до огромных скоростей, позволяя ей пробивать дыры в броне и разрушать ее.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%92%D0%B5%D0%BB%D0%BE%D1%86%D0%B8%D1%82%D1%83%D1%81",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "벨로시투스 리시버",
+        "description": "<p>The Velocitus is an Archwing Gauss-gun that deals heavy charged shot damage. It is the first Archwing weapon to have base  Magnetic damage. </p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Velocitus",
+        "drop": [
+            {
+                "name": "Steel Meridian",
+                "link": null
+            }
+        ]
+    },
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Velocitus Set.json
+++ b/queued_updates/items/Velocitus Set.json
@@ -1,0 +1,39 @@
+{
+    "_id": "582b0f850af25410b099f7f8",
+    "tags": [
+        "parts",
+        "archwing",
+        "set"
+    ],
+    "icon": "icons/en/Velocitus_Set.0e2289bd3cc8bba9a0393d1fad061ab6.png",
+    "thumb": "icons/en/thumbs/Velocitus_Set.0e2289bd3cc8bba9a0393d1fad061ab6.128x128.png",
+    "icon_format": "land",
+    "url_name": "velocitus_set",
+    "tradable": true,
+    "part_of_set": [
+        "582b0f850af25410b099f7f8",
+        "5783beebd9b6753790c89e88",
+        "5783bf0ad9b6753790c89e89",
+        "5783bf10d9b6753790c89e8a"
+    ],
+    "set_root": true,
+    "en": {
+        "item_name": "Velocitus Set",
+        "description": "<p>The Velocitus is an Archwing Gauss-gun that deals heavy charged shot damage. It is the first Archwing weapon to have base  Magnetic damage. </p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Velocitus",
+        "drop": []
+    },
+    "ru": {
+        "item_name": "Велоцитус Комплект",
+        "description": "<p>Полностью заряженный, магнитный ствол Велоцитуса разгоняет металлическую болванку до огромных скоростей, позволяя ей пробивать дыры в броне и разрушать ее.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%92%D0%B5%D0%BB%D0%BE%D1%86%D0%B8%D1%82%D1%83%D1%81",
+        "drop": []
+    },
+    "ko": {
+        "item_name": "벨로시투스 세트",
+        "description": "<p>The Velocitus is an Archwing Gauss-gun that deals heavy charged shot damage. It is the first Archwing weapon to have base  Magnetic damage. </p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Velocitus",
+        "drop": []
+    },
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Velocitus Stock.json
+++ b/queued_updates/items/Velocitus Stock.json
@@ -1,0 +1,55 @@
+{
+    "_id": "5783bf10d9b6753790c89e8a",
+    "tags": [
+        "parts",
+        "archwing",
+        "stock"
+    ],
+    "icon": "icons/en/Velocitus_Set.0e2289bd3cc8bba9a0393d1fad061ab6.png",
+    "thumb": "icons/en/thumbs/Velocitus_Set.0e2289bd3cc8bba9a0393d1fad061ab6.128x128.png",
+    "icon_format": "land",
+    "sub_icon": "sub_icons/stock_128x128.png",
+    "url_name": "velocitus_stock",
+    "tradable": true,
+    "part_of_set": [
+        "582b0f850af25410b099f7f8",
+        "5783beebd9b6753790c89e88",
+        "5783bf0ad9b6753790c89e89",
+        "5783bf10d9b6753790c89e8a"
+    ],
+    "set_root": false,
+    "en": {
+        "item_name": "Velocitus Stock",
+        "description": "<p>The Velocitus is an Archwing Gauss-gun that deals heavy charged shot damage. It is the first Archwing weapon to have base  Magnetic damage. </p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Velocitus",
+        "drop": [
+            {
+                "name": "Red Veil",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Велоцитус Приклад",
+        "description": "<p>Полностью заряженный, магнитный ствол Велоцитуса разгоняет металлическую болванку до огромных скоростей, позволяя ей пробивать дыры в броне и разрушать ее.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%92%D0%B5%D0%BB%D0%BE%D1%86%D0%B8%D1%82%D1%83%D1%81",
+        "drop": [
+            {
+                "name": "Red Veil",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "벨로시투스 스톡",
+        "description": "<p>The Velocitus is an Archwing Gauss-gun that deals heavy charged shot damage. It is the first Archwing weapon to have base  Magnetic damage. </p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Velocitus",
+        "drop": [
+            {
+                "name": "Red Veil",
+                "link": null
+            }
+        ]
+    },
+    "trading_tax": 2000
+}

--- a/queued_updates/items/Voltage Sequence.json
+++ b/queued_updates/items/Voltage Sequence.json
@@ -1,0 +1,62 @@
+{
+    "_id": "5911f11d97a0add8e9d5da4e",
+    "tags": [
+        "mod",
+        "lanka"
+    ],
+    "icon": "icons/en/Voltage_Sequence.65e42495eb08f41e8bbeb35b041e981a.png",
+    "thumb": "icons/en/thumbs/Voltage_Sequence.65e42495eb08f41e8bbeb35b041e981a.128x128.png",
+    "icon_format": "port",
+    "url_name": "voltage_sequence",
+    "tradable": true,
+    "en": {
+        "item_name": "Voltage Sequence",
+        "description": "<p>Voltage Sequence turns flying enemies killed by Lanka into electric traps for a short duration. It also adds a Sequence effect.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Voltage_Sequence",
+        "drop": [
+            {
+                "name": "Operation: Ambulas Reborn",
+                "link": null
+            },
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Последовательность Напряжения",
+        "description": "<p>Последовательность Напряжения — Мод-Аугмент для оружия Ланка, который преобразует убитого летающего врага в ловушку и даёт прирост синдикат-эффекта — Последовательность.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%9F%D0%BE%D1%81%D0%BB%D0%B5%D0%B4%D0%BE%D0%B2%D0%B0%D1%82%D0%B5%D0%BB%D1%8C%D0%BD%D0%BE%D1%81%D1%82%D1%8C_%D0%9D%D0%B0%D0%BF%D1%80%D1%8F%D0%B6%D0%B5%D0%BD%D0%B8%D1%8F",
+        "icon": "icons/ru/Voltage_Sequence.126dca38357c6c1484b7c748e0bb07c2.png",
+        "thumb": "icons/ru/thumbs/Voltage_Sequence.126dca38357c6c1484b7c748e0bb07c2.128x128.png",
+        "drop": [
+            {
+                "name": "Operation: Ambulas Reborn",
+                "link": null
+            },
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "볼티지 시퀀스",
+        "description": "<p>Voltage Sequence turns flying enemies killed by Lanka into electric traps for a short duration. It also adds a Sequence effect.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Voltage_Sequence",
+        "drop": [
+            {
+                "name": "Operation: Ambulas Reborn",
+                "link": null
+            },
+            {
+                "name": "The Perrin Sequence",
+                "link": null
+            }
+        ]
+    },
+    "rarity": "rare",
+    "mod_max_rank": 3,
+    "trading_tax": 8000
+}

--- a/queued_updates/items/Winds of Purity.json
+++ b/queued_updates/items/Winds of Purity.json
@@ -1,0 +1,51 @@
+{
+    "_id": "54a74455e779892d5e51569a",
+    "tags": [
+        "mod",
+        "weapons",
+        "rare"
+    ],
+    "icon": "icons/en/Winds_of_Purity.1ddc46bdcc0721c654edf27fe0e430cb.png",
+    "thumb": "icons/en/thumbs/Winds_of_Purity.1ddc46bdcc0721c654edf27fe0e430cb.128x128.png",
+    "icon_format": "port",
+    "url_name": "winds_of_purity",
+    "tradable": true,
+    "en": {
+        "item_name": "Winds of Purity",
+        "description": "<p>The Winds of Purity mod is a Weapon Augment Mod that adds Life Steal and Purity specifically for the Furis. It increases Life Steal by 0.05 and Purity by 0.25 per rank, at a maximum of 0.2 and 1 at rank 3, respectively.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Winds_of_Purity",
+        "drop": [
+            {
+                "name": "New Loka",
+                "link": null
+            }
+        ]
+    },
+    "ru": {
+        "item_name": "Ветер чистоты",
+        "description": "<p>Ветер Чистоты — мод-аугмент для оружия Фурис, который регенерирует здоровье при нанесении удара и даёт прирост Синдикат-эффекта - Чистота.</p>",
+        "wiki_link": "http://ru.warframe.wikia.com/wiki/%D0%92%D0%B5%D1%82%D0%B5%D1%80_%D1%87%D0%B8%D1%81%D1%82%D0%BE%D1%82%D1%8B",
+        "icon": "icons/ru/Winds_of_Purity.f240608213bac0e1c215edc5922cdbb3.png",
+        "thumb": "icons/ru/thumbs/Winds_of_Purity.f240608213bac0e1c215edc5922cdbb3.128x128.png",
+        "drop": [
+            {
+                "name": "New Loka",
+                "link": null
+            }
+        ]
+    },
+    "ko": {
+        "item_name": "윈드 오브 퓨리티",
+        "description": "<p>The Winds of Purity mod is a Weapon Augment Mod that adds Life Steal and Purity specifically for the Furis. It increases Life Steal by 0.05 and Purity by 0.25 per rank, at a maximum of 0.2 and 1 at rank 3, respectively.</p>",
+        "wiki_link": "http://warframe.wikia.com/wiki/Winds_of_Purity",
+        "drop": [
+            {
+                "name": "New Loka",
+                "link": null
+            }
+        ]
+    },
+    "rarity": "rare",
+    "mod_max_rank": 3,
+    "trading_tax": 8000
+}


### PR DESCRIPTION
- corrected broken drop source listings
- added drop sources for Syndicates where missing
- all Syndicate drop sources have been standardized to the format "<Syndicate>" (without " Offering")
- "The Perrin Sequence" instead of "Perrin Sequence" everywhere