### PR TITLE
Add Mod: Mark of the Beast

### DIFF
--- a/queued_updates/items/Mark of the Beast.json
+++ b/queued_updates/items/Mark of the Beast.json
@@ -1,0 +1,17 @@
+{
+    "tags": [
+        "mod"
+    ],
+    "icon": "https://static.wikia.nocookie.net/warframe/images/c/c5/MarkoftheBeastMod.png/revision/latest?cb=20210129220657",
+    "tradable": true,
+    "part of set": false,
+    "en": {
+        "item_name": "Mark of the Beast",
+        "description": "<p>The Mark of the Beast mod increases status and critical chance by 20.0% per rank for a maximum of 120% for secondary weapons on 6 melee kills within 6 seconds.</p>",
+        "wiki_link": "https://warframe.fandom.com/wiki/Mark_of_the_Beast",
+        "drop": []
+    },
+    "rarity": "rare",
+    "mod_max_rank": 5,
+    "trading_tax": 8000
+}


### PR DESCRIPTION
It was mentioned that this was missing in my clan chat. The folks that have it said it was tradeable and that it wasn't linkable in game or searchable on warframe.market.