### PR TITLE
Primed Ammo Stock

### DIFF
--- a/missing/items/Primed Ammo Stock
+++ b/missing/items/Primed Ammo Stock
@@ -1,0 +1,33 @@
+{
+    "_id": "",
+    "tags": [
+        "prime",
+        "mod",
+        "legendary",
+        "shotgun",
+        "primary"
+    ],
+    "icon": "https://static.wikia.nocookie.net/warframe/images/2/28/PrimedAmmoStockPlaceholder.png",
+    "thumb": "",
+    "icon_format": "",
+    "url_name": "primed_ammo_stock",
+    "tradable": true,
+    "game_ref": {
+        "uniq_name": ""
+    },
+    "en": {
+        "item_name": "Primed Ammo Stock",
+        "description": "+110% Magazine Capacity",
+        "wiki_link": "https://warframe.fandom.com/wiki/Primed_Cryo_Rounds",
+        "drop": []
+    },
+    "it": {
+        "item_name": "Primed Ammo Stock",
+        "description": "+110% Capacità Caricatore",
+        "wiki_link": "https://warframe.fandom.com/it/wiki/Ammo_Stock",
+        "drop": []
+    },
+    "rarity": "legendary",
+    "max_rank": 10,
+    "trading_tax": 1000000
+}


### PR DESCRIPTION
Mod appeared in baro ki'teer inventory, unlinkable in game yet.
More Localization needs to be added.