### PR TITLE
fix: ru translate

### DIFF
--- a/tracked/items/Fracturing Wind.json
+++ b/tracked/items/Fracturing Wind.json
@@ -22,7 +22,7 @@
     "ru": {
         "item_name": "Разрывающий Ветер",
         "description": "Быстрые, множественные удары с мощными добивающими.",
-        "wiki_link": "https://warframe.fandom.com/ru/wiki/%D0%A0%D0%B0%D0%B7%D1%80%D1%8B%D0%B2%D0%B0%D1%8E%D1%89%D0%B8%D0%B9_%D0%92%D0%B5%D1%82%D0%B5%D1%80",
+        "wiki_link": "https://warframe.fandom.com/ru/wiki/Разрывающий_Ветер",
         "icon": "icons/ru/Fracturing_Wind.35754ce4315b6b850de118c65cbacc60.png",
         "thumb": "icons/ru/thumbs/Fracturing_Wind.35754ce4315b6b850de118c65cbacc60.128x128.png",
         "drop": []

--- a/tracked/items/Rending Wind.json
+++ b/tracked/items/Rending Wind.json
@@ -21,7 +21,7 @@
         "drop": []
     },
     "ru": {
-        "item_name": "Разрывающий Ветер",
+        "item_name": "Разрывающий Ветер (Конклав)",
         "description": "Форма боя, созданная для Конклава.",
         "wiki_link": "https://warframe.fandom.com/ru/wiki/%D0%A0%D0%B0%D0%B7%D1%80%D1%8B%D0%B2%D0%B0%D1%8E%D1%89%D0%B8%D0%B9_%D0%92%D0%B5%D1%82%D0%B5%D1%80",
         "icon": "icons/ru/Rending_Wind.cb912de83e69c057385d4d5146d72d04.png",

--- a/tracked/items/Rending Wind.json
+++ b/tracked/items/Rending Wind.json
@@ -23,7 +23,7 @@
     "ru": {
         "item_name": "Разрывающий Ветер (Конклав)",
         "description": "Форма боя, созданная для Конклава.",
-        "wiki_link": "https://warframe.fandom.com/ru/wiki/%D0%A0%D0%B0%D0%B7%D1%80%D1%8B%D0%B2%D0%B0%D1%8E%D1%89%D0%B8%D0%B9_%D0%92%D0%B5%D1%82%D0%B5%D1%80",
+        "wiki_link": "https://warframe.fandom.com/ru/wiki/Разрывающий_Ветер_(конклав)",
         "icon": "icons/ru/Rending_Wind.cb912de83e69c057385d4d5146d72d04.png",
         "thumb": "icons/ru/thumbs/Rending_Wind.cb912de83e69c057385d4d5146d72d04.128x128.png",
         "drop": []


### PR DESCRIPTION
(ru)
В русском переводе два мода называются одинаково из конклава и из обычного режима, поэтому я решил, что было бы неплохо добавить подпись "конклав" для мода из конклава.
_________________________________________________________
(eng)
In the Russian translation, the two mods are called the same from the conclave and from the normal mode, so I decided it would be nice to add the signature "conclave" for the mod from the conclave.
_________________________________________________________

mods:
rending wind
fracturing wind