### PR TITLE
fatal teleport > teleport rush

### DIFF
--- a/tracked/items/Teleport Rush.json
+++ b/tracked/items/Teleport Rush.json
@@ -6,9 +6,9 @@
         "warframe",
         "ash"
     ],
-    "icon": "items/images/en/fatal_teleport.88b75d1675894c1efec4b62c74cd0ce9.png",
+    "icon": "https://wiki.warframe.com/images/TeleportRushMod.png?81f61",
     "thumb": "items/images/en/thumbs/fatal_teleport.88b75d1675894c1efec4b62c74cd0ce9.128x128.png",
-    "url_name": "fatal_teleport",
+    "url_name": "teleport_rush",
     "tradable": true,
     "game_ref": {
         "uniq_name": "/Lotus/Powersuits/Ninja/TeleportToAugmentCard"
@@ -17,8 +17,8 @@
         "en": {
             "item_name": "Teleport Rush",
             "description": "Teleport Augment: Using Teleport increases Parkour Velocity by 30% for 12s. Executing a target with Teleport extends Smoke Screen's duration by 5s. Mercy Kills fully refresh the duration.",
-            "wiki_link": "https://wiki.warframe.com/w/Fatal_Teleport",
-            "icon": "items/images/en/fatal_teleport.88b75d1675894c1efec4b62c74cd0ce9.png",
+            "wiki_link": "https://wiki.warframe.com/w/Teleport_Rush",
+            "icon": "https://wiki.warframe.com/images/TeleportRushMod.png?81f61",
             "thumb": "items/images/en/thumbs/fatal_teleport.88b75d1675894c1efec4b62c74cd0ce9.128x128.png"
         },
         "ru": {


### PR DESCRIPTION
Wiki, Icon & url were still the old fatal teleport.

I couldn't find a local location for the icons, so I used the wiki one instead.